### PR TITLE
`commitlint` warns on non-lower-cased subject

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,7 @@
-module.exports = {extends: ['@commitlint/config-conventional']}
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    // Any rules defined here will override rules from @commitlint/config-conventional
+    rules: {
+        'subject-case': [1, 'always', 'lower-case'],
+    },
+}


### PR DESCRIPTION
Closes: #34

<!--- Title -->

Description
-----------

`commitlint` now only warns on non-lower-cased subject, instead of erroring out. See workflow output for example in this PR.

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.