### PR TITLE
Add basic E2E tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,5 @@
 name: Java Build
-permissions:
-  pull-requests: write
+permissions: {}
 
 on:
   push:
@@ -21,7 +20,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
         java: [ "11", "17" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/.github/workflows/commits.yaml
+++ b/.github/workflows/commits.yaml
@@ -13,7 +13,7 @@ jobs:
   commits:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         node: ["20"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,70 @@
+name: Java E2E
+permissions: {}
+
+on:
+  push:
+    branches: ["main"]
+
+  pull_request:
+    branches: ["main", "release-*"]
+
+  schedule:
+    # daily at 2:30 UTC
+    - cron: "30 2 * * *"
+
+concurrency:
+  group: java-e2e-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        java: ["11", "17"]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.LOCALSTACK_DUMMY_ACCESS_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.LOCALSTACK_DUMMY_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+      KAFKA_TOPIC: eventbridge-e2e
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        with:
+          distribution: "temurin"
+          java-version: ${{ matrix.java }}
+          cache: "maven"
+      - name: Build JAR Artifacts and verify coverage
+        run: mvn --batch-mode --no-transfer-progress --errors --update-snapshots clean package -Drevision=$(git describe --tags --always)
+      - name: Start Kafka and Localstack
+        working-directory: e2e
+        run: docker-compose -f docker_compose.yaml up -d --quiet-pull
+      - name: Wait for Kafka Connect REST API
+        run: curl --retry 10 --retry-delay 5 --retry-all-errors http://localhost:8083/connectors\?expand=status\&expand=info
+      - name: Deploy EventBridge Connector
+        working-directory: e2e
+        run: curl -i --fail-with-body -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @connect-config-json.json
+      - name: Create Localstack AWS Resources
+        run: |
+          aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name ${KAFKA_TOPIC}
+          aws --endpoint-url=http://localhost:4566 events put-rule --name ${KAFKA_TOPIC} --event-pattern "{\"source\":[{\"prefix\":\"kafka-connect\"}]}"
+          aws --endpoint-url=http://localhost:4566 events put-targets --rule ${KAFKA_TOPIC} --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:000000000000:${KAFKA_TOPIC}"
+      - name: Send Event to Kafka
+        run: |
+          docker run --rm --network e2e_default --env "BROKERS=kafka:29092" deviceinsight/kafkactl:v3.1.0 produce ${KAFKA_TOPIC} --key=my-key --value="{\"sentTime\":\"$(date)\"}"
+          # give cluster some time to process the message before turning it off
+          sleep 5
+      - name: Query Task State
+        run: |
+          # Naive assertion for now until we have real E2E tests
+          TASK_STATE=$(curl --fail-with-body -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/eventbridge-e2e/status | jq -r '.tasks[0].state')
+          if [[ ${TASK_STATE} != "RUNNING" ]]; then 
+            echo "::error::Expected task state to not be \"${TASK_STATE}\""
+          fi
+      - name: Dump logs
+        if: always()
+        run: docker-compose -f e2e/docker_compose.yaml logs 
+

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,7 +16,7 @@ jobs:
   format:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
         java: [ "11" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -3,14 +3,13 @@ permissions: {}
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 jobs:
   git-secrets:
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-22.04 ]
         java: [ "11" ]
     runs-on: ${{ matrix.os }}
     env:

--- a/e2e/connect-config-json.json
+++ b/e2e/connect-config-json.json
@@ -1,0 +1,15 @@
+{
+    "name": "eventbridge-e2e",
+    "config": {
+        "auto.offset.reset": "earliest",
+        "connector.class": "software.amazon.event.kafkaconnector.EventBridgeSinkConnector",
+        "topics": "eventbridge-e2e",
+        "aws.eventbridge.connector.id": "eventbridge-e2e-connector",
+        "aws.eventbridge.eventbus.arn": "arn:aws:events:us-east-1:000000000000:event-bus/default",
+        "aws.eventbridge.region": "us-east-1",
+        "aws.eventbridge.endpoint.uri": "http://localstack:4566",
+        "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter.schemas.enable": false
+    }
+}

--- a/e2e/connect-log4j.properties
+++ b/e2e/connect-log4j.properties
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log4j.rootLogger=INFO, stdout, connectAppender
+log4j.logger.software.amazon.event.kafkaconnector=TRACE
+
+# Send the logs to the console.
+#
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+# Send the logs to a file, rolling the file at midnight local time. For example, the `File` option specifies the
+# location of the log files (e.g. ${kafka.logs.dir}/connect.log), and at midnight local time the file is closed
+# and copied in the same directory but with a filename that ends in the `DatePattern` option.
+#
+log4j.appender.connectAppender=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.connectAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
+
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log messages, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector.
+#
+connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+
+log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
+log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
+
+log4j.logger.org.apache.zookeeper=ERROR
+log4j.logger.org.reflections=ERROR

--- a/e2e/connect-standalone.properties
+++ b/e2e/connect-standalone.properties
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These are defaults. This file just demonstrates how to override some settings.
+bootstrap.servers=kafka:29092
+
+# The converters specify the format of data in Kafka and how to translate it into Connect data. Every Connect user will
+# need to configure these based on the format they want their data in when loaded from or stored into Kafka
+key.converter=org.apache.kafka.connect.json.JsonConverter
+value.converter=org.apache.kafka.connect.json.JsonConverter
+# Converter-specific settings can be passed in by prefixing the Converter's setting with the converter we want to apply
+# it to
+2=true
+value.converter.schemas.enable=true
+
+offset.storage.file.filename=/tmp/connect.offsets
+# Flush much faster than normal, which is useful for testing/debugging
+offset.flush.interval.ms=10000
+
+# Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
+# (connectors, converters, transformations). The list should consist of top level directories that include
+# any combination of:
+# a) directories immediately containing jars with plugins and their dependencies
+# b) uber-jars with plugins and their dependencies
+# c) directories immediately containing the package directory structure of classes of plugins and their dependencies
+# Note: symlinks will be followed to discover dependencies or plugins.
+# Examples:
+# plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors,
+plugin.path=/usr/local/share/java/connect

--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -1,0 +1,46 @@
+version: "3"
+
+services:
+  kafka:
+    image: docker.io/bitnami/kafka:3.4
+    ports:
+      - 9092:9092
+    environment:
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_ENABLE_KRAFT: 'true'
+      KAFKA_CFG_NODE_ID: 1
+      KAFKA_CFG_BROKER_ID: 1
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_CFG_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@kafka:29093'
+      KAFKA_CFG_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_CFG_LOG_DIRS: '/tmp/kraft-combined-logs'
+    volumes:
+      - ${PWD}/log4j.properties:/opt/bitnami/kafka/config/log4j.properties
+  connect:
+    image: docker.io/bitnami/kafka:3.4
+    depends_on:
+      - kafka
+    ports:
+      - 8083:8083
+    environment:
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    volumes:
+      - ${PWD}/connect-standalone.properties:/opt/bitnami/kafka/config/connect-standalone.properties
+      - ${PWD}/connect-log4j.properties:/opt/bitnami/kafka/config/connect-log4j.properties
+      - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
+    command: /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties
+  localstack:
+    image: localstack/localstack:2.1
+    ports:
+      - "127.0.0.1:4566:4566" # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559" # external services port range
+    environment:
+      - DEBUG=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/e2e/log4j.properties
+++ b/e2e/log4j.properties
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Unspecified loggers and loggers with additivity=true output to server.log and stdout
+# Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
+log4j.rootLogger=WARN, stdout, kafkaAppender
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.kafkaAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.stateChangeAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.requestAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.cleanerAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.controllerAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+log4j.appender.authorizerAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+
+# Change the line below to adjust ZK client logging
+log4j.logger.org.apache.zookeeper=WARN
+
+# Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+log4j.logger.kafka=WARN
+log4j.logger.org.apache.kafka=WARN
+
+# Change to DEBUG or TRACE to enable request logging
+log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.additivity.kafka.request.logger=false
+
+# Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+# related to the handling of requests
+#log4j.logger.kafka.network.Processor=TRACE, requestAppender
+#log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
+#log4j.additivity.kafka.server.KafkaApis=false
+log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
+log4j.additivity.kafka.network.RequestChannel$=false
+
+# Change the line below to adjust KRaft mode controller logging
+log4j.logger.org.apache.kafka.controller=INFO, controllerAppender
+log4j.additivity.org.apache.kafka.controller=false
+
+# Change the line below to adjust ZK mode controller logging
+log4j.logger.kafka.controller=TRACE, controllerAppender
+log4j.additivity.kafka.controller=false
+
+log4j.logger.kafka.log.LogCleaner=INFO, cleanerAppender
+log4j.additivity.kafka.log.LogCleaner=false
+
+log4j.logger.state.change.logger=WARN, stateChangeAppender
+log4j.additivity.state.change.logger=false
+
+# Access denials are logged at INFO level, change to DEBUG to also log allowed accesses
+log4j.logger.kafka.authorizer.logger=INFO, authorizerAppender
+log4j.additivity.kafka.authorizer.logger=false
+log4j.appender.stdout.Threshold=OFF

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@
                             <excludes>
                                 <exclude>**/README</exclude>
                                 <exclude>**/NOTICE</exclude>
+                                <exclude>e2e/**</exclude>
                                 <exclude>**/commitlint.config.js</exclude>
                                 <exclude>**/THIRD-PARTY-LICENSES</exclude>
                                 <exclude>src/test/resources/**</exclude>


### PR DESCRIPTION
<!--- Title -->

Description
-----------

- Upgrade CI workflows to Ubuntu 22.04 (new E2E workflows require it because a newer `curl` version is required)
- Add basic E2E tests to the CI pipeline
  - Build the connector (same as `build.yaml` for now)
  - Deploy Kafka broker (w/ Kraft), Kafka Connect (both Bitnami) and [Localstack](https://localstack.cloud/)
  - Deploy the connector
  - Create SQS queue and EventBridge Rule/Target to send to SQS on pattern match
  - Send an event
  - Assert that the connector keeps running, i.e., no exception thrown after sending the event
  - Dump logs so one can inspect if the event was sent to EventBridge*

> **Note**  
> Due to a [bug](https://github.com/localstack/localstack/issues/8472) in Localstack, we currently can't assert the event was delivered to SQS. Once this bug is fixed, these E2E tests will be replaced by Java E2E tests.

Test Steps
-----------

Runs on PRs, commits to main, and scheduled.
[Tested](https://github.com/embano1/eventbridge-kafka-connector/actions/runs/5236887049/jobs/9454713345) in my forked repo since this workflows requires secrets access which are not allowed from forked repos (hence the steps are failing here).

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes: #38

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.