### PR TITLE
ci: allow longer commitlint bodies

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,9 @@ module.exports = {
     extends: ['@commitlint/config-conventional'],
     // Any rules defined here will override rules from @commitlint/config-conventional
     rules: {
+        // warn only
         'subject-case': [1, 'always', 'lower-case'],
+        // fail
+        'body-max-length': [2, 'always', 200]
     },
 }


### PR DESCRIPTION
commitlint errors when body is larger than 200 chars, instead of 100 (default config)

Closes: #44

<!--- Title -->

Description
-----------

<!--- Describe your changes in detail. -->

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.