### PR TITLE
[WIP] fix: resend only failed `SinkRecord`s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <joda-time.version>2.12.5</joda-time.version>
         <org.apache.commons.version>3.12.0</org.apache.commons.version>
         <org.apache.logging.log4j.version>2.20.0</org.apache.logging.log4j.version>
+        <org.assertj.version>3.24.2</org.assertj.version>
         <org.hamcrest.version>2.2</org.hamcrest.version>
         <org.jacoco.version>0.8.10</org.jacoco.version>
         <org.junit.jupiter.version>5.9.3</org.junit.jupiter.version>
@@ -62,6 +63,11 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -173,6 +179,12 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>${org.apache.logging.log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${org.assertj.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkTask.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkTask.java
@@ -37,9 +37,10 @@ public class EventBridgeSinkTask extends SinkTask {
   public void start(Map<String, String> properties) {
     log.info("Starting Kafka Connect task for EventBridgeSinkConnector");
 
-    config = new EventBridgeSinkConfig(properties);
-    eventBridgeWriter = new EventBridgeWriter(config);
+    var config = new EventBridgeSinkConfig(properties);
+    var eventBridgeWriter = new EventBridgeWriter(config);
 
+    ErrantRecordReporter dlq;
     try {
       dlq = context.errantRecordReporter();
     } catch (NoSuchMethodError | NoClassDefFoundError e) {
@@ -48,6 +49,15 @@ public class EventBridgeSinkTask extends SinkTask {
     if (dlq != null) {
       log.info("Dead-letter queue enabled");
     }
+
+    startInternal(config, eventBridgeWriter, dlq);
+  }
+
+  void startInternal(
+      EventBridgeSinkConfig config, EventBridgeWriter eventBridgeWriter, ErrantRecordReporter dlq) {
+    this.config = config;
+    this.eventBridgeWriter = eventBridgeWriter;
+    this.dlq = dlq;
     statusReporter.startAsync();
   }
 

--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkTaskTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkTaskTest.java
@@ -4,19 +4,131 @@
  */
 package software.amazon.event.kafkaconnector;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
+import software.amazon.awssdk.services.eventbridge.model.EventBridgeException;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsResponse;
 
 @ExtendWith(MockitoExtension.class)
 public class EventBridgeSinkTaskTest {
 
+  private final ObjectMapper mapper = new ObjectMapper();
+
   @Mock private EventBridgeAsyncClient eventBridgeAsyncClient;
+  @Mock private ErrantRecordReporter dlq;
+
+  private final EventBridgeSinkConfig config =
+      new EventBridgeSinkConfig(
+          Map.of(
+              "aws.eventbridge.retries.max", 10,
+              "aws.eventbridge.connector.id", "someId",
+              "aws.eventbridge.region", "eu-central-1",
+              "aws.eventbridge.eventbus.arn", "something",
+              "aws.eventbridge.detail.types", "my-first-${topic}"));
+
+  @BeforeEach
+  void resetMocks() {
+    reset(eventBridgeAsyncClient, dlq);
+  }
 
   @Test
-  public void returnsSuccessfulRecords() {
-    // Todo: Add tests for SinkTask
+  @DisplayName("should send records successfully")
+  public void sendSuccessfully() {
+    when(eventBridgeAsyncClient.putEvents(any(PutEventsRequest.class)))
+        .thenReturn(completedFuture(PutEventsResponse.builder().failedEntryCount(0).build()))
+        .thenReturn(completedFuture(PutEventsResponse.builder().failedEntryCount(0).build()));
+
+    var writer = new EventBridgeWriter(eventBridgeAsyncClient, config);
+
+    var task = new EventBridgeSinkTask();
+    task.startInternal(config, writer, dlq);
+
+    task.put(List.of(createTestRecordWithId("one"), createTestRecordWithId("two")));
+
+    var captor = ArgumentCaptor.forClass(PutEventsRequest.class);
+    verify(eventBridgeAsyncClient, times(2)).putEvents(captor.capture());
+
+    assertThat(captor.getAllValues())
+        .extracting(fromPutEventsRequestDetail(detail -> detail.get("value").get("id").asText()))
+        .containsExactly(List.of("one"), List.of("two"));
+  }
+
+  @Test
+  @DisplayName("should resend only retryable failed records")
+  public void resendRetryable() {
+
+    when(eventBridgeAsyncClient.putEvents(any(PutEventsRequest.class)))
+        .thenReturn(completedFuture(PutEventsResponse.builder().failedEntryCount(0).build()))
+        .thenThrow(
+            AwsServiceException.builder()
+                .cause(EventBridgeException.builder().statusCode(500).build())
+                .build())
+        .thenReturn(completedFuture(PutEventsResponse.builder().failedEntryCount(0).build()));
+
+    var writer = new EventBridgeWriter(eventBridgeAsyncClient, config);
+
+    var task = new EventBridgeSinkTask();
+    task.startInternal(config, writer, dlq);
+
+    task.put(List.of(createTestRecordWithId("one"), createTestRecordWithId("two")));
+
+    var captor = ArgumentCaptor.forClass(PutEventsRequest.class);
+    verify(eventBridgeAsyncClient, times(3)).putEvents(captor.capture());
+
+    assertThat(captor.getAllValues())
+        .extracting(fromPutEventsRequestDetail(detail -> detail.get("value").get("id").asText()))
+        .containsExactly(List.of("one"), List.of("two"), List.of("two"));
+  }
+
+  private SinkRecord createTestRecordWithId(String id) {
+    var valueSchema = SchemaBuilder.struct().field("id", Schema.STRING_SCHEMA).build();
+    var value = new Struct(valueSchema).put("id", id);
+
+    return new SinkRecord("topic", 0, Schema.STRING_SCHEMA, "key", valueSchema, value, 0);
+  }
+
+  private <T> Function<PutEventsRequest, List<T>> fromPutEventsRequestDetail(
+      Function<JsonNode, T> f) {
+    return (PutEventsRequest request) ->
+        request.entries().stream()
+            .map(PutEventsRequestEntry::detail)
+            .map(
+                detail -> {
+                  try {
+                    return f.apply(mapper.readTree(detail));
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(toList());
   }
 }


### PR DESCRIPTION
Description
-----------

Successful send `SinkRecord`s should be send only once.

Test Steps
-----------

```bash
$ mvn clean test
```

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#46 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.