### PR TITLE
ci: add sleep before connector deployment

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         java: ["11", "17"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     env:
@@ -46,7 +47,10 @@ jobs:
         run: curl --retry 10 --retry-delay 5 --retry-all-errors http://localhost:8083/connectors\?expand=status\&expand=info
       - name: Deploy EventBridge Connector
         working-directory: e2e
-        run: curl -i --fail-with-body -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @connect-config-json.json
+        run: |
+          # connect status seems flaky, wait a bit before registering
+          sleep 3
+          curl -i --fail-with-body -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @connect-config-json.json
       - name: Create Localstack AWS Resources
         run: |
           aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name ${KAFKA_TOPIC}


### PR DESCRIPTION
Connect seems to be flaky reporting status success too early

<!--- Title -->

Description
-----------

<!--- Describe your changes in detail. -->

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.