### PR TITLE
ci: remove kafkactl

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,6 +30,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: test
       AWS_DEFAULT_REGION: us-east-1
       KAFKA_TOPIC: eventbridge-e2e
+      BOOTSTRAP_SERVER: kafka:29092
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Set up JDK ${{ matrix.java }}
@@ -56,9 +57,9 @@ jobs:
           aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name ${KAFKA_TOPIC}
           aws --endpoint-url=http://localhost:4566 events put-rule --name ${KAFKA_TOPIC} --event-pattern "{\"source\":[{\"prefix\":\"kafka-connect\"}]}"
           aws --endpoint-url=http://localhost:4566 events put-targets --rule ${KAFKA_TOPIC} --targets "Id"="1","Arn"="arn:aws:sqs:us-east-1:000000000000:${KAFKA_TOPIC}"
-      - name: Send Event to Kafka
+      - name: Send an Event to Kafka
         run: |
-          docker run --rm --network e2e_default --env "BROKERS=kafka:29092" deviceinsight/kafkactl:v3.1.0 produce ${KAFKA_TOPIC} --key=my-key --value="{\"sentTime\":\"$(date)\"}"
+          docker exec -e KAFKA_TOPIC=${KAFKA_TOPIC} -e BOOTSTRAP_SERVER=${BOOTSTRAP_SERVER} kafka-e2e /bin/bash -c 'echo -n {\"testEventSentTime\":\"$(date)\"} | /opt/bitnami/kafka/bin/kafka-console-producer.sh --bootstrap-server ${BOOTSTRAP_SERVER} --topic ${KAFKA_TOPIC}'
           # give cluster some time to process the message before turning it off
           sleep 5
       - name: Query Task State

--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -1,7 +1,13 @@
 version: "3"
 
+networks:
+  e2e:
+    name: e2e
 services:
   kafka:
+    container_name: kafka-e2e
+    networks:
+      - e2e
     image: docker.io/bitnami/kafka:3.4
     ports:
       - 9092:9092
@@ -21,6 +27,9 @@ services:
     volumes:
       - ${PWD}/log4j.properties:/opt/bitnami/kafka/config/log4j.properties
   connect:
+    container_name: connect-e2e
+    networks:
+      - e2e
     image: docker.io/bitnami/kafka:3.4
     depends_on:
       - kafka
@@ -29,12 +38,16 @@ services:
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
     volumes:
       - ${PWD}/connect-standalone.properties:/opt/bitnami/kafka/config/connect-standalone.properties
       - ${PWD}/connect-log4j.properties:/opt/bitnami/kafka/config/connect-log4j.properties
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
     command: /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties
   localstack:
+    container_name: localstack-e2e
+    networks:
+      - e2e
     image: localstack/localstack:2.1
     ports:
       - "127.0.0.1:4566:4566" # LocalStack Gateway


### PR DESCRIPTION
<!--- Title -->

Description
-----------

- Remove `kafkactl` image and use `kafka-console-producer.sh` instead to speed up the CI run.
- Use fixed names in `docker-compose`

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.