### PR TITLE
ci: multiple kafka version tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         java: ["11", "17"]
+        kafka: ["3.4.0","3.4.1"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -30,6 +31,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: test
       AWS_DEFAULT_REGION: us-east-1
       KAFKA_TOPIC: eventbridge-e2e
+      KAFKA_VERSION: ${{ matrix.kafka }}
       BOOTSTRAP_SERVER: kafka:29092
       EVENT: '"{\"testMessage\":\"eventbridge-e2e\"}"'
     steps:
@@ -40,5 +42,5 @@ jobs:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
           cache: "maven"
-      - name: Run E2E Tests
+      - name: Run Kafka ${{ matrix.kafka }} E2E Tests
         run: mvn --batch-mode --no-transfer-progress --errors --update-snapshots clean verify -Drevision=$(git describe --tags --always)

--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.4.1}
     ports:
       - "9092:9092"
     environment:
@@ -21,7 +21,7 @@ services:
     volumes:
       - ${PWD}/log4j.properties:/opt/bitnami/kafka/config/log4j.properties
   connect:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.4.1}
     depends_on:
       - kafka
     ports:
@@ -34,7 +34,7 @@ services:
       - ${PWD}/connect-standalone.properties:/opt/bitnami/kafka/config/connect-standalone.properties
       - ${PWD}/connect-log4j.properties:/opt/bitnami/kafka/config/connect-log4j.properties
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
-    command: /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties
+    command: ["/bin/bash","-c","env && /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties"]
   localstack:
     image: localstack/localstack:latest
     ports:


### PR DESCRIPTION
<!--- Title -->

Description
-----------

CI now runs E2E against multiple Kafka (Connect) versions (currently `3.4.0` and `3.4.1`). `docker-compose` file by default uses `3.4.1` unless overwritten with environment variable `KAFKA_VERSION`. Also dump Kafka environment variables on start to ease debugging.

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.