### PR TITLE
Update E2E tests

### DIFF
--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -36,12 +36,11 @@ services:
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
     command: ["/bin/bash","-c","env && /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties"]
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:2.2.0
     ports:
       - "4566:4566" # LocalStack Gateway
       - "4510-4559:4510-4559" # external services port range
     environment:
-      - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/e2e/docker_compose_redpanda.yaml
+++ b/e2e/docker_compose_redpanda.yaml
@@ -33,12 +33,11 @@ services:
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
     command: ["/bin/bash","-c","env && /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties"]
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:2.2.0
     ports:
       - "4566:4566" # LocalStack Gateway
       - "4510-4559:4510-4559" # external services port range
     environment:
-      - DEBUG=1
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <!-- The following logger can be used for containers logs since 1.18.0 -->
+    <logger name="tc" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Disable `DEBUG` logging in testcontainers: configure `ch.qos.logback` used in tests to disable `DEBUG` level and reduce noice in E2E tests.


Use `2.2.0` tag for `localstack`: since a stable tag has been released after `2.1.0` with the required changes needed to run our E2E suite, this change uses a tagged `2.2.0` version for `localstack`.

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#86


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.