### PR TITLE
perf: avoid string conversion

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
@@ -11,11 +11,10 @@ import static software.amazon.event.kafkaconnector.EventBridgeResult.Error.repor
 import static software.amazon.event.kafkaconnector.EventBridgeResult.failure;
 import static software.amazon.event.kafkaconnector.EventBridgeResult.success;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 import java.util.List;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.json.JsonConverter;
@@ -67,7 +66,7 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
     }
   }
 
-  private String createJsonPayload(SinkRecord record) throws JsonProcessingException {
+  private String createJsonPayload(SinkRecord record) throws IOException {
     var root = objectMapper.createObjectNode();
     root.put("topic", record.topic());
     root.put("partition", record.kafkaPartition());
@@ -103,9 +102,9 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
    *
    * @param record Kafka record to be sent to EventBridge
    * @return headers to be added to EventBridge message
-   * @throws JsonProcessingException
+   * @throws IOException
    */
-  private ArrayNode createHeaderArray(SinkRecord record) throws JsonProcessingException {
+  private ArrayNode createHeaderArray(SinkRecord record) throws IOException {
     var headersArray = objectMapper.createArrayNode();
 
     for (Header header : record.headers()) {
@@ -125,9 +124,9 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
    *
    * @param jsonBytes - byteArray to convert to JSON
    * @return the JSON representation of jsonBytes
-   * @throws JsonProcessingException
+   * @throws IOException
    */
-  private JsonNode createJSONFromByteArray(byte[] jsonBytes) throws JsonProcessingException {
-    return objectMapper.readTree(new String(jsonBytes, StandardCharsets.UTF_8));
+  private JsonNode createJSONFromByteArray(byte[] jsonBytes) throws IOException {
+    return objectMapper.readTree(jsonBytes);
   }
 }


### PR DESCRIPTION


<!--- Title -->

Description
-----------

We pass `byte[]` to `createJSONFromByteArray` so there's no need for an additional `String` conversion since `readTree` accepts `byte[]` as well.

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes: #88


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.