### PR TITLE
fix: remove putIfAbsent calls

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultEventBridgeMapper.java
@@ -73,12 +73,12 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
     root.put("offset", record.kafkaOffset());
     root.put("timestamp", record.timestamp());
     root.put("timestampType", record.timestampType().toString());
-    root.putIfAbsent("headers", createHeaderArray(record));
+    root.set("headers", createHeaderArray(record));
 
     if (record.key() == null) {
-      root.putIfAbsent("key", null);
+      root.set("key", null);
     } else {
-      root.putIfAbsent(
+      root.set(
           "key",
           createJSONFromByteArray(
               jsonConverter.fromConnectData(record.topic(), record.keySchema(), record.key())));
@@ -86,9 +86,9 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
 
     // tombstone handling
     if (record.value() == null) {
-      root.putIfAbsent("value", null);
+      root.set("value", null);
     } else {
-      root.putIfAbsent(
+      root.set(
           "value",
           createJSONFromByteArray(
               jsonConverter.fromConnectData(record.topic(), record.valueSchema(), record.value())));
@@ -109,7 +109,7 @@ public class DefaultEventBridgeMapper implements EventBridgeMapper {
 
     for (Header header : record.headers()) {
       var headerItem = objectMapper.createObjectNode();
-      headerItem.putIfAbsent(
+      headerItem.set(
           header.key(),
           createJSONFromByteArray(
               jsonConverter.fromConnectHeader(


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Remove `putIfAbsent` calls to support older Kafka Connect environments (using Jackson <`2.13`) and replace deprecated `JsonNode` `put` calls (for `String` type values) with `set`.

Test Steps
-----------

Successfully tested with `docker.io/bitnami/kafka:2.7.0-debian-10-r124`, not throwing `Caused by: java.lang.NoSuchMethodError` exception anymore.

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes: #122


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.