### PR TITLE
Prototype of S3 ConsumerInterceptor

### DIFF
--- a/e2e/connect-config.json
+++ b/e2e/connect-config.json
@@ -10,6 +10,12 @@
         "aws.eventbridge.endpoint.uri": "http://localstack:4566",
         "key.converter": "org.apache.kafka.connect.storage.StringConverter",
         "value.converter": "org.apache.kafka.connect.json.JsonConverter",
-        "value.converter.schemas.enable": false
+        "value.converter.schemas.enable": false,
+        "consumer.override.interceptor.classes": "software.amazon.event.kafkaconnector.EventBridgeSinkInterceptor",
+        "consumer.override.aws.eventbridge.value": "json",
+        "consumer.override.aws.eventbridge.s3.threshold_bytes": "16",
+        "consumer.override.aws.eventbridge.s3.bucket_name": "example",
+        "consumer.override.aws.eventbridge.s3.region": "us-east-1",
+        "consumer.override.aws.eventbridge.s3.endpoint.uri": "http://localstack:4566"
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>http-client-spi</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkInterceptor.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkInterceptor.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class EventBridgeSinkInterceptor<K, V> implements ConsumerInterceptor<K, V> {
+
+  private static final Logger logger = LoggerFactory.getLogger(EventBridgeSinkInterceptor.class);
+
+  private final Map<String, Object> configs = new HashMap<>();
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  private S3Client s3 = null;
+  private String bucketName = null;
+  private int thresholdBytes = 4 * 1024;
+
+  @Override
+  public ConsumerRecords<K, V> onConsume(ConsumerRecords<K, V> records) {
+    logger.debug("onConsume({}) {}", records, configs.get("aws.eventbridge.connector.id"));
+
+    if ("json".equals(configs.get("aws.eventbridge.value"))) {
+      final Map<TopicPartition, List<ConsumerRecord<K, V>>> result = new HashMap<>();
+      for (var partition : records.partitions()) {
+        var recordsOfPartition = new ArrayList<ConsumerRecord<K, V>>();
+        for (var record : records.records(partition)) {
+          var bytes = (byte[]) record.value();
+          logger.debug("record value bytes: {}", bytes.length);
+          if (bytes.length > thresholdBytes) {
+
+            var s3key = UUID.randomUUID().toString();
+            var req = PutObjectRequest.builder().bucket(bucketName).key(s3key).build();
+
+            s3.putObject(req, RequestBody.fromBytes(bytes));
+
+            var headers = new RecordHeaders(record.headers());
+            headers.add("s3", s3key.getBytes());
+            var copy =
+                new ConsumerRecord<>(
+                    record.topic(),
+                    record.partition(),
+                    record.offset(),
+                    record.timestamp(),
+                    record.timestampType(),
+                    record.serializedKeySize(),
+                    record.serializedValueSize(),
+                    record.key(),
+                    (V) null,
+                    headers,
+                    record.leaderEpoch());
+            logger.debug("add record with reference");
+            recordsOfPartition.add(copy);
+          } else {
+            logger.debug("add original record");
+            recordsOfPartition.add(record);
+          }
+        }
+        logger.debug("add/map {} records to partition {}", recordsOfPartition.size(), partition);
+        result.put(partition, recordsOfPartition);
+      }
+      return new ConsumerRecords<K, V>(result);
+    } else if ("string".equals(configs.get("aws.eventbridge.value"))) {
+      records.forEach(
+          record -> logger.info("record: {}", new String((byte[]) record.value()))); // charset?
+    }
+
+    return records;
+  }
+
+  @Override
+  public void onCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    logger.debug("onCommit({})", offsets);
+  }
+
+  @Override
+  public void close() {
+    logger.debug("close()");
+    s3.close();
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    logger.debug("configure({})", configs);
+    this.configs.clear();
+    this.configs.putAll(configs);
+
+    var credentialProvioder = DefaultCredentialsProvider.create();
+    var region = Region.of((String) configs.get("aws.eventbridge.s3.region"));
+    var endpointURI = (String) configs.get("aws.eventbridge.s3.endpoint.uri");
+
+    var s3ClientBuilder =
+        S3Client.builder().region(region).credentialsProvider(credentialProvioder);
+
+    if (endpointURI != null) {
+      try {
+        s3ClientBuilder.endpointOverride(new URI(endpointURI)).forcePathStyle(true);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    s3 = s3ClientBuilder.build();
+    bucketName = (String) configs.get("aws.eventbridge.s3.bucket_name");
+    if (configs.containsKey("aws.eventbridge.s3.threshold_bytes")) {
+      thresholdBytes = Integer.parseInt((String) configs.get("aws.eventbridge.s3.threshold_bytes"));
+    }
+  }
+}


### PR DESCRIPTION
Description
-----------

Prototype to intercept consumer records to apply claim-check via AWS S3 before records reach sink task.

Test Steps
-----------

The connector configuration file `e2e/connect-config.json` is prepared for LocalStack. The threshold for the full Kafka message (as bytes) is 16 byte. Each Kafka message w/ a payload exceeding 16 Bytes will produce a S3 object with an UUID as key. The key is added to the Kafka message header `s3` and send to EventBridge. The modified payload is `null` currently which should/must be corrected (not a tombstone).

Before send messages to the connector one has to create the S3 bucket `example` in LocalStack:
```bash
$ awslocal s3api create-bucket --bucket example
```

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#125 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.