### PR TITLE
test: use dynamic ports for Kafka Connect and Localstack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,20 +140,20 @@ Change the JSON configuration example `connect-config.json` (uses LocalStack def
 environment. In a separate terminal (within the `e2e` folder) deploy the connector:
 
 ```bash
-curl -i --fail-with-body -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://localhost:8083/connectors/ -d @connect-config.json
+curl -i --fail-with-body -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://$(docker-compose -f docker_compose.yaml port connect 8083)/connectors/ -d @connect-config.json
 ```
 
 The output should look like:
 
 ```bash
 HTTP/1.1 201 Created
-Date: Tue, 04 Jul 2023 09:35:48 GMT
-Location: http://localhost:8083/connectors/eventbridge-e2e
+Date: Fri, 24 Nov 2023 14:11:22 GMT
+Location: http://0.0.0.0:32816/connectors/eventbridge-e2e
 Content-Type: application/json
-Content-Length: 636
-Server: Jetty(9.4.51.v20230217)
+Content-Length: 688
+Server: Jetty(9.4.52.v20230823)
 
-{"name":"eventbridge-e2e","config":{"auto.offset.reset":"earliest","connector.class":"software.amazon.event.kafkaconnector.EventBridgeSinkConnector","topics":"eventbridge-e2e","aws.eventbridge.connector.id":"eventbridge-e2e-connector","aws.eventbridge.eventbus.arn":"arn:aws:events:us-east-1:1234567890:event-bus/eventbridge-e2e","aws.eventbridge.region":"us-east-1","key.converter":"org.apache.kafka.connect.storage.StringConverter","value.converter":"org.apache.kafka.connect.json.JsonConverter","value.converter.schemas.enable":"false","name":"eventbridge-e2e"},"tasks":[{"connector":"eventbridge-e2e","task":0}],"type":"sink"}
+{"name":"eventbridge-e2e","config":{"auto.offset.reset":"earliest","connector.class":"software.amazon.event.kafkaconnector.EventBridgeSinkConnector","topics":"eventbridge-e2e","aws.eventbridge.connector.id":"eventbridge-e2e-connector","aws.eventbridge.eventbus.arn":"arn:aws:events:us-east-1:000000000000:event-bus/eventbridge-e2e","aws.eventbridge.region":"us-east-1","aws.eventbridge.endpoint.uri":"http://localstack:4566","key.converter":"org.apache.kafka.connect.storage.StringConverter","value.converter":"org.apache.kafka.connect.json.JsonConverter","value.converter.schemas.enable":"false","name":"eventbridge-e2e"},"tasks":[{"connector":"eventbridge-e2e","task":0}],"type":"sink"}
 ```
 
 Before proceeding, verify that the Docker Compose logs do not show any errors, such as `WARN`, `ERROR`, or `FATAL` log
@@ -168,7 +168,7 @@ Produce a Kafka record to invoke the EventBridge sink connector:
 
 ```bash
 # open a shell in the Kafka broker container
-docker exec -it -w /opt/bitnami/kafka/bin e2e-kafka-1 /bin/bash
+docker-compose -f docker_compose.yaml exec -w /opt/bitnami/kafka/bin kafka /bin/bash
 
 # produce an event
 # replace the topic with your connector settings if needed

--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -20,12 +20,13 @@ services:
       KAFKA_CFG_LOG_DIRS: '/tmp/kraft-combined-logs'
     volumes:
       - ${PWD}/log4j.properties:/opt/bitnami/kafka/config/log4j.properties
+
   connect:
     image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.0}
     depends_on:
       - kafka
     ports:
-      - "8083:8083"
+      - "8083"
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -35,12 +36,8 @@ services:
       - ${PWD}/connect-log4j.properties:/opt/bitnami/kafka/config/connect-log4j.properties
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
     command: ["/bin/bash","-c","env && /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties"]
+
   localstack:
     image: localstack/localstack:3.0.0
     ports:
-      - "4566:4566" # LocalStack Gateway
-      - "4510-4559:4510-4559" # external services port range
-    environment:
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "4566" # LocalStack Gateway

--- a/e2e/docker_compose_confluent.yaml
+++ b/e2e/docker_compose_confluent.yaml
@@ -5,7 +5,6 @@ services:
     image: confluentinc/cp-kafka:${KAFKA_VERSION:-7.5.1}
     ports:
       - "9092:9092"
-      - "9101:9101"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
@@ -14,8 +13,6 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_JMX_PORT: 9101
-      KAFKA_JMX_HOSTNAME: localhost
       KAFKA_PROCESS_ROLES: "broker,controller"
       KAFKA_CONTROLLER_QUORUM_VOTERS: "1@kafka:29093"
       KAFKA_LISTENERS: "PLAINTEXT://kafka:29092,CONTROLLER://kafka:29093,PLAINTEXT_HOST://0.0.0.0:9092"
@@ -31,7 +28,7 @@ services:
     depends_on:
       - kafka
     ports:
-      - "8083:8083"
+      - "8083"
     environment:
       CONNECT_BOOTSTRAP_SERVERS: "kafka:29092"
       CONNECT_REST_ADVERTISED_HOST_NAME: connect
@@ -60,9 +57,4 @@ services:
   localstack:
     image: localstack/localstack:3.0.0
     ports:
-      - "4566:4566" # LocalStack Gateway
-      - "4510-4559:4510-4559" # external services port range
-    environment:
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "4566"

--- a/e2e/docker_compose_redpanda.yaml
+++ b/e2e/docker_compose_redpanda.yaml
@@ -17,12 +17,13 @@ services:
     image: docker.redpanda.com/redpandadata/redpanda:v23.2.12
     ports:
       - "9092:9092"
+
   connect:
     image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.0}
     depends_on:
       - kafka
     ports:
-      - "8083:8083"
+      - "8083"
     environment:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
@@ -32,12 +33,8 @@ services:
       - ${PWD}/connect-log4j.properties:/opt/bitnami/kafka/config/connect-log4j.properties
       - ${PWD}/../target:/usr/local/share/java/connect/kafka-eventbridge-sink
     command: ["/bin/bash","-c","env && /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/connect-standalone.properties"]
+
   localstack:
     image: localstack/localstack:3.0.0
     ports:
-      - "4566:4566" # LocalStack Gateway
-      - "4510-4559:4510-4559" # external services port range
-    environment:
-      - DOCKER_HOST=unix:///var/run/docker.sock
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "4566"

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.18.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>


### PR DESCRIPTION
Description
-----------

Improve (Docker) compose files to use dynamic ports for Kafka Connect and Localstack to not depend on possible used ones. Integration tests are updated to use resolved exposed ports. Non used ports e.g. JMX are removed from compose files.

To use a dynamic port for Kafka the advertised listeners must be updated to the resolved port [1] which is not supported by Testcontainers 'Docker Compose Module' [2].

Closes #171.

[1]: https://github.com/testcontainers/testcontainers-java/blob/main/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
[2]: https://java.testcontainers.org/modules/docker_compose/


Test Steps
-----------

Run integration tests.

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.