### PR TITLE
feat: add support for different authentication profiles

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
@@ -27,6 +27,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
       "aws.eventbridge.eventbus.global.endpoint.id";
   static final String AWS_RETRIES_CONFIG = "aws.eventbridge.retries.max";
   static final String AWS_RETRIES_DELAY_CONFIG = "aws.eventbridge.retries.delay";
+  static final String AWS_PROFILE_NAME_CONFIG = "aws.eventbridge.iam.profile.name";
   static final String AWS_ROLE_ARN_CONFIG = "aws.eventbridge.iam.role.arn";
   static final String AWS_ROLE_EXTERNAL_ID_CONFIG = "aws.eventbridge.iam.external.id";
   static final String AWS_DETAIL_TYPES_CONFIG = "aws.eventbridge.detail.types";
@@ -48,6 +49,8 @@ public class EventBridgeSinkConfig extends AbstractConfig {
           + "If not specified, AWS default credentials provider is used";
   private static final String AWS_ROLE_EXTERNAL_ID_CONFIG_DOC =
       "The IAM external id (optional) when role-based authentication is used";
+  private static final String AWS_PROFILE_NAME_CONFIG_DOC =
+      "The profile to use from the configuration and credentials files to retrieve IAM credentials";
   private static final String AWS_DETAIL_TYPES_DEFAULT = "kafka-connect-${topic}";
   private static final String AWS_DETAIL_TYPES_DOC =
       "The detail-type that will be used for the EventBridge events. "
@@ -66,6 +69,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
   public final String endpointURI;
   public final String roleArn;
   public final String externalId;
+  public final String profileName;
   public final List<String> resources;
   public final int maxRetries;
   public final long retriesDelay;
@@ -82,6 +86,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
     this.endpointURI = getString(AWS_ENDPOINT_URI_CONFIG);
     this.roleArn = getString(AWS_ROLE_ARN_CONFIG);
     this.externalId = getString(AWS_ROLE_EXTERNAL_ID_CONFIG);
+    this.profileName = getString(AWS_PROFILE_NAME_CONFIG);
     this.maxRetries = getInt(AWS_RETRIES_CONFIG);
     this.retriesDelay = getInt(AWS_RETRIES_DELAY_CONFIG);
     this.resources = getList(AWS_EVENTBUS_RESOURCES_CONFIG);
@@ -137,6 +142,9 @@ public class EventBridgeSinkConfig extends AbstractConfig {
         "",
         Importance.MEDIUM,
         AWS_ROLE_EXTERNAL_ID_CONFIG_DOC);
+    configDef.define(
+        AWS_PROFILE_NAME_CONFIG, Type.STRING, "", Importance.MEDIUM, AWS_PROFILE_NAME_CONFIG_DOC);
+    ;
     configDef.define(
         AWS_RETRIES_CONFIG, Type.INT, AWS_RETRIES_DEFAULT, Importance.MEDIUM, AWS_RETRIES_DOC);
     configDef.define(

--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
@@ -33,8 +33,8 @@ public class EventBridgeCredentialsProvider {
    */
   public static AwsCredentialsProvider getCredentials(EventBridgeSinkConfig config) {
     if (config.roleArn.trim().isBlank()) {
-      log.info("Using aws default credentials provider: role arn not set");
-      return DefaultCredentialsProvider.create();
+      log.info("Using aws default credentials provider");
+      return getDefaultCredentialsProvider(config);
     }
 
     log.info(
@@ -44,6 +44,23 @@ public class EventBridgeCredentialsProvider {
         config.connectorId,
         config.externalId,
         stsRefreshDuration);
+    return getStsAssumeRoleCredentialsProvider(config);
+  }
+
+  private static DefaultCredentialsProvider getDefaultCredentialsProvider(
+      EventBridgeSinkConfig config) {
+    var builder = DefaultCredentialsProvider.builder();
+
+    var profileName = config.profileName;
+    if (!profileName.isBlank()) {
+      builder.profileName(profileName);
+    }
+
+    return builder.build();
+  }
+
+  private static StsAssumeRoleCredentialsProvider getStsAssumeRoleCredentialsProvider(
+      EventBridgeSinkConfig config) {
     var stsClient = StsClient.builder().region(Region.of(config.region)).build();
     var requestBuilder =
         AssumeRoleRequest.builder()


### PR DESCRIPTION
Add support to specify a profile from configuration and credential files to retrieve credentials so that each connector can be configured with different IAM settings if needed. This is currently not possible because in Kafka Connect Java system properties and environment variables, including `AWS_PROFILE`, are global for all connectors.

Closes: #191

<!--- Title -->

Description
-----------

- [x] Add configuration option `aws.eventbridge.iam.profile.name`
- [x] Fail fast when IAM credentials cannot be retrieved (UX improvement)
- [x] Update README (improve wording, add description for new feature)

Test Steps
-----------

- Verify existing behavior with environment variables to retrieve credentials or using `aws.eventbridge.iam.role.arn` continue to work
- Verified that specifying a profile with `aws.eventbridge.iam.profile.name` and mounting AWS credential and configuration files into Kafka Connect works*
- Existing tests pass
- New test added

\* If one or more of the documented AWS credentials environment variables and `AWS_PROFILE` environment variable are set, the connector will throw an exception to ease debugging and fail fast:

```
e2e-connect-1     | org.apache.kafka.common.config.ConfigException: "[AWS_PROFILE, AWS_ACCESS_KEY_ID]" environment variable(s) are set. Unset the environment variable for "aws.eventbridge.iam.profile.name" to take effect.
```

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.