### PR TITLE
Support sidelining large events/payloads to an external event store

### DIFF
--- a/e2e/connect-config-s3.json
+++ b/e2e/connect-config-s3.json
@@ -1,0 +1,17 @@
+{
+    "name": "eventbridge-e2e-s3",
+    "config": {
+        "auto.offset.reset": "earliest",
+        "connector.class": "software.amazon.event.kafkaconnector.EventBridgeSinkConnector",
+        "topics": "eventbridge-e2e",
+        "aws.eventbridge.connector.id": "eventbridge-e2e-connector",
+        "aws.eventbridge.eventbus.arn": "arn:aws:events:us-east-1:000000000000:event-bus/eventbridge-e2e",
+        "aws.eventbridge.region": "us-east-1",
+        "aws.eventbridge.endpoint.uri": "http://localstack:4566",
+        "aws.eventbridge.offloading.s3.default.bucket": "test-bucket",
+        "aws.eventbridge.offloading.default.fieldref": "$.detail.value.message",
+        "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+        "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+        "value.converter.schemas.enable": false
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <commons-codec.version>1.17.0</commons-codec.version>
         <commons-logging.version>1.3.1</commons-logging.version>
         <connect.api.version>3.7.0</connect.api.version>
+        <equalsverifier.version>3.16.1</equalsverifier.version>
         <joda-time.version>2.12.7</joda-time.version>
         <org.apache.commons.version>3.14.0</org.apache.commons.version>
         <org.assertj.version>3.25.3</org.assertj.version>
@@ -36,6 +37,7 @@
         <org.junit.jupiter.version>5.10.2</org.junit.jupiter.version>
         <org.mockito.version>5.11.0</org.mockito.version>
         <org.slf4j.version>2.0.13</org.slf4j.version>
+        <org.skyscreamer.version>1.5.1</org.skyscreamer.version>
         <org.testcontainers.version>1.19.7</org.testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -48,7 +50,16 @@
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -101,6 +112,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth-crt</artifactId>
         </dependency>
@@ -121,6 +137,10 @@
                     <artifactId>netty-nio-client</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -159,6 +179,11 @@
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${com.jayway.jsonpath.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path-assert</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
             </dependency>
@@ -176,6 +201,11 @@
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>${joda-time.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>nl.jqno.equalsverifier</groupId>
+                <artifactId>equalsverifier</artifactId>
+                <version>${equalsverifier.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -239,6 +269,11 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${org.testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>${org.skyscreamer.version}</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>

--- a/src/main/java/software/amazon/event/kafkaconnector/cache/Cache.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/cache/Cache.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.cache;
+
+import java.util.function.Function;
+
+public interface Cache<K, V> {
+
+  V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction);
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/cache/FifoCache.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/cache/FifoCache.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.cache;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class FifoCache<K, V> implements Cache<K, V> {
+
+  private static class SizeLimitedLinkedHashMap<K, V> extends LinkedHashMap<K, V> {
+
+    private final int maxSize;
+
+    public SizeLimitedLinkedHashMap(int maxSize) {
+      super(maxSize);
+      this.maxSize = maxSize;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+      return size() > maxSize;
+    }
+  }
+
+  private final HashMap<K, V> delegate;
+
+  public FifoCache(int maxSize) {
+    if (maxSize < 1) {
+      throw new IllegalArgumentException("Maximum size must be at least one.");
+    }
+    this.delegate = new SizeLimitedLinkedHashMap<>(maxSize);
+  }
+
+  @Override
+  public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+    return delegate.computeIfAbsent(key, mappingFunction);
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/cache/MessageDigestCacheKey.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/cache/MessageDigestCacheKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.cache;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+public final class MessageDigestCacheKey {
+
+  private final byte[] bytes;
+
+  private MessageDigestCacheKey(byte[] bytes) {
+    this.bytes = bytes;
+  }
+
+  public static MessageDigestCacheKey sha512Of(final String value) {
+    try {
+      var md = MessageDigest.getInstance("SHA-512");
+      return new MessageDigestCacheKey(md.digest(value.getBytes()));
+    } catch (final NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(bytes);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    var that = (MessageDigestCacheKey) o;
+    return Arrays.equals(bytes, that.bytes);
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/EventBridgeEventDetailValueOffloadingStrategy.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/EventBridgeEventDetailValueOffloadingStrategy.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.offloading;
+
+import java.util.List;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.event.kafkaconnector.mapping.EventBridgeMappingResult;
+import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
+
+@FunctionalInterface
+public interface EventBridgeEventDetailValueOffloadingStrategy {
+
+  EventBridgeMappingResult apply(
+      List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries);
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloading.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloading.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.offloading;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.event.kafkaconnector.mapping.EventBridgeMappingResult;
+import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
+
+public class NoOpEventBridgeEventDetailValueOffloading
+    implements EventBridgeEventDetailValueOffloadingStrategy {
+
+  @Override
+  public EventBridgeMappingResult apply(
+      List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries) {
+    return new EventBridgeMappingResult(putEventsRequestEntries, emptyList());
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloading.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloading.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.offloading;
+
+import static com.jayway.jsonpath.Configuration.defaultConfiguration;
+import static com.jayway.jsonpath.Option.SUPPRESS_EXCEPTIONS;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneOffset.UTC;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+import static software.amazon.awssdk.core.async.AsyncRequestBody.fromString;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.Error.panic;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.Error.retry;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.failure;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.success;
+import static software.amazon.event.kafkaconnector.cache.MessageDigestCacheKey.sha512Of;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.event.kafkaconnector.EventBridgeResult;
+import software.amazon.event.kafkaconnector.cache.Cache;
+import software.amazon.event.kafkaconnector.cache.FifoCache;
+import software.amazon.event.kafkaconnector.cache.MessageDigestCacheKey;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
+import software.amazon.event.kafkaconnector.mapping.EventBridgeMappingResult;
+import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
+import software.amazon.event.kafkaconnector.util.ThrowingFunction;
+import software.amazon.event.kafkaconnector.util.ThrowingFunctionApplyException;
+
+public class S3EventBridgeEventDetailValueOffloading
+    implements EventBridgeEventDetailValueOffloadingStrategy {
+
+  public static final String JSON_PATH_PREFIX = "$.detail.value";
+
+  private static final int SDK_TIMEOUT = 5000; // timeout in milliseconds for SDK calls
+
+  // maximum size of cache (by Map.Entry<MessageDigestCacheKey, UUID>) => ~16MiB
+  // size of each Map.Entry<MessageDigestCacheKey, UUID> is 168Byte (for x86_64)
+  private static final int MAX_CACHE_SIZE = 100_000;
+
+  private static final Logger logger =
+      ContextAwareLoggerFactory.getLogger(S3EventBridgeEventDetailValueOffloading.class);
+
+  private static final Configuration jsonPathConfiguration =
+      defaultConfiguration()
+          .addOptions(
+              SUPPRESS_EXCEPTIONS // suppress exception otherwise
+              // com.jayway.jsonpath.ReadContext#read throws an exception if JSON path could not
+              // be found
+              );
+
+  private final String bucketName;
+  private final S3AsyncClient client;
+
+  private final Cache<MessageDigestCacheKey, UUID> s3ObjectKeyCache;
+  private final Supplier<UUID> idGenerator;
+
+  private static final JsonPath jsonPathAdd = JsonPath.compile("$");
+
+  private final String jsonPathExp;
+  private final JsonPath jsonPathRemove;
+
+  public S3EventBridgeEventDetailValueOffloading(
+      final S3AsyncClient client,
+      final String bucketName,
+      final String jsonPathExp,
+      final Cache<MessageDigestCacheKey, UUID> s3ObjectKeyCache,
+      final Supplier<UUID> idGenerator) {
+
+    this.bucketName = bucketName;
+    this.client = client;
+
+    this.s3ObjectKeyCache = s3ObjectKeyCache;
+    this.idGenerator = idGenerator;
+
+    this.jsonPathExp = jsonPathExp;
+    this.jsonPathRemove = compileRestrictedJsonPath(jsonPathExp);
+  }
+
+  public S3EventBridgeEventDetailValueOffloading(
+      final S3AsyncClient client, final String bucketName, final String jsonPathExp) {
+
+    this.bucketName = bucketName;
+    this.client = client;
+
+    this.s3ObjectKeyCache = new FifoCache<>(MAX_CACHE_SIZE);
+    this.idGenerator = UUID::randomUUID;
+
+    this.jsonPathExp = jsonPathExp;
+    this.jsonPathRemove = compileRestrictedJsonPath(jsonPathExp);
+  }
+
+  private static JsonPath compileRestrictedJsonPath(String value) {
+    JsonPath jsonPath;
+    try {
+      jsonPath = JsonPath.compile(value);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(format("Invalid JSON Path '%s'.", value));
+    }
+
+    if (!jsonPath.getPath().startsWith("$['detail']['value']")) {
+      throw new IllegalArgumentException(
+          format("JSON Path must start with '%s' but is '%s'.", JSON_PATH_PREFIX, value));
+    }
+    if (!jsonPath.isDefinite()) {
+      throw new IllegalArgumentException(
+          format("JSON Path must be definite but '%s' is not.", value));
+    }
+    // rewrite $.detail -> $,
+    // because PutEventsRequestEntry#detail is the sub document of $.detail
+    return JsonPath.compile("$" + jsonPath.getPath().substring("$['detail']".length()));
+  }
+
+  public static void validateJsonPath(String jsonPathExp) {
+    compileRestrictedJsonPath(jsonPathExp);
+  }
+
+  @Override
+  public EventBridgeMappingResult apply(
+      final List<MappedSinkRecord<PutEventsRequestEntry>> putEventsRequestEntries) {
+
+    var result =
+        putEventsRequestEntries.stream()
+            .map(this::apply)
+            .collect(partitioningBy(EventBridgeResult::isSuccess));
+
+    var success = result.get(true).stream().map(EventBridgeResult::success).collect(toList());
+    var errors = result.get(false).stream().map(EventBridgeResult::failure).collect(toList());
+
+    return new EventBridgeMappingResult(success, errors);
+  }
+
+  private EventBridgeResult<PutEventsRequestEntry> apply(
+      final MappedSinkRecord<PutEventsRequestEntry> item) {
+
+    var sinkRecord = item.getSinkRecord();
+    var putEventsRequestEntry = item.getValue();
+
+    try {
+      var documentContext = JsonPath.parse(putEventsRequestEntry.detail(), jsonPathConfiguration);
+
+      var value = documentContext.read(jsonPathRemove);
+      if (value != null) {
+        var payload =
+            value instanceof Map || value instanceof List
+                ? JsonPath.parse(value).jsonString()
+                : value.toString();
+        documentContext
+            .delete(jsonPathRemove)
+            .put(jsonPathAdd, "dataref", s3ArnOf(putS3Object(payload)))
+            .put(jsonPathAdd, "datarefJsonPath", jsonPathExp);
+      }
+
+      return success(
+          sinkRecord, putEventsRequestEntry.copy(it -> it.detail(documentContext.jsonString())));
+
+    } catch (final ThrowingFunctionApplyException e) {
+      var unwrapped = e.getCause();
+      if (unwrapped instanceof ExecutionException
+          || unwrapped instanceof InterruptedException
+          || unwrapped instanceof TimeoutException) {
+
+        var cause = unwrapped.getCause();
+        if (cause instanceof S3Exception && ((S3Exception) cause).statusCode() < 500) {
+          return failure(sinkRecord, panic(e));
+        }
+        return failure(sinkRecord, retry(e));
+      }
+      return failure(sinkRecord, panic(unwrapped));
+    }
+  }
+
+  private String s3ArnOf(UUID uuid) {
+    return format("arn:aws:s3:::%s/%s", bucketName, uuid);
+  }
+
+  private UUID putS3Object(final String payload) {
+    var durationHolder = new Duration[] {null};
+    var s3ObjectId =
+        s3ObjectKeyCache.computeIfAbsent(
+            sha512Of(payload),
+            ThrowingFunction.wrap(
+                (sha512) -> {
+                  var id = idGenerator.get();
+                  var request =
+                      PutObjectRequest.builder().bucket(bucketName).key(id.toString()).build();
+
+                  var body = fromString(payload, UTF_8);
+
+                  var start = OffsetDateTime.now(UTC);
+                  logger.trace("uploading object to s3 with key={}", s3ArnOf(id));
+                  client.putObject(request, body).get(SDK_TIMEOUT, MILLISECONDS);
+                  durationHolder[0] = Duration.between(start, OffsetDateTime.now(UTC));
+
+                  return id;
+                }));
+
+    var duration = durationHolder[0];
+    logger.trace(
+        "s3 offloading completed: jsonPath='{}' key={} cache={} durationMillis={}",
+        jsonPathExp,
+        s3ArnOf(s3ObjectId),
+        duration == null ? "HIT" : "MISS",
+        duration == null ? "0" : duration.toMillis());
+
+    return s3ObjectId;
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/util/ThrowingFunction.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/util/ThrowingFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.util;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ThrowingFunction<T, R> {
+
+  R apply(T t) throws Throwable;
+
+  static <T, R> Function<T, R> wrap(ThrowingFunction<T, R> f) {
+    return t -> {
+      try {
+        return f.apply(t);
+      } catch (Throwable e) {
+        throw new ThrowingFunctionApplyException(e);
+      }
+    };
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/util/ThrowingFunctionApplyException.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/util/ThrowingFunctionApplyException.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.util;
+
+public class ThrowingFunctionApplyException extends RuntimeException {
+  public ThrowingFunctionApplyException(Throwable e) {
+    super(e);
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/AbstractEventBridgeSinkConnectorIT.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/AbstractEventBridgeSinkConnectorIT.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector;
+
+import static java.net.http.HttpClient.newBuilder;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.UUID;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.json.JsonSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+@TestInstance(PER_CLASS)
+@Testcontainers
+public abstract class AbstractEventBridgeSinkConnectorIT {
+
+  private static final String BOOTSTRAP_SERVER = "localhost:9092";
+
+  //  environment variables
+  private static final String COMPOSE_FILE_ENV = "COMPOSE_FILE";
+  private static final String KAFKA_VERSION_ENV = "KAFKA_VERSION";
+
+  private static final String CONNECT_SERVICE = "connect_1";
+  private static final int CONNECT_EXPOSED_SERVICE_PORT = 8083;
+
+  private static final String LOCALSTACK_SERVICE = "localstack_1";
+  private static final int LOCALSTACK_EXPOSED_SERVICE_PORT = 4566;
+
+  private static final String AWS_ACCESS_KEY_ID = "test";
+  private static final String AWS_SECRET_ACCESS_KEY = "test";
+
+  private final String RUNNING_STATE = "RUNNING";
+
+  protected final String TEST_RESOURCE_NAME = "eventbridge-e2e";
+
+  protected final String TEST_BUCKET_NAME = "test-bucket";
+
+  protected static final Logger log =
+      LoggerFactory.getLogger(AbstractEventBridgeSinkConnectorIT.class);
+
+  @Container
+  private static final DockerComposeContainer<?> environment =
+      new DockerComposeContainer<>("e2e", getComposeFile())
+          .withLogConsumer("connect", new Slf4jLogConsumer(log).withSeparateOutputStreams())
+          .withEnv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
+          .withEnv("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
+          .withEnv(KAFKA_VERSION_ENV, getKafkaVersion())
+          .withExposedService(
+              CONNECT_SERVICE, CONNECT_EXPOSED_SERVICE_PORT, Wait.forHttp("/connectors"))
+          .withExposedService(
+              LOCALSTACK_SERVICE,
+              LOCALSTACK_EXPOSED_SERVICE_PORT,
+              Wait.forHttp("/_localstack/health"));
+
+  protected HttpClient httpClient = newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+
+  protected S3Client s3client;
+
+  protected SqsClient sqsClient;
+
+  private KafkaProducer<String, JsonNode> kafkaProducer =
+      new KafkaProducer<>(
+          ImmutableMap.of(
+              BOOTSTRAP_SERVERS_CONFIG,
+              BOOTSTRAP_SERVER,
+              CLIENT_ID_CONFIG,
+              UUID.randomUUID().toString(),
+              ACKS_CONFIG,
+              "all",
+              RETRIES_CONFIG,
+              2),
+          new StringSerializer(),
+          new JsonSerializer());
+
+  @BeforeAll
+  public void createAwsResources() {
+    log.info("creating aws localstack resources");
+    var credentials =
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY));
+
+    s3client =
+        S3Client.builder()
+            .endpointOverride(getLocalstackEndpoint())
+            .forcePathStyle(true)
+            .credentialsProvider(credentials)
+            .region(Region.US_EAST_1)
+            .build();
+
+    var createBucketRequest = CreateBucketRequest.builder().bucket(TEST_BUCKET_NAME).build();
+
+    var s3response = s3client.createBucket(createBucketRequest);
+    if (!s3response.sdkHttpResponse().isSuccessful()) {
+      fail("failed to create bucket: " + s3response.sdkHttpResponse());
+    }
+
+    sqsClient =
+        SqsClient.builder()
+            .endpointOverride(getLocalstackEndpoint())
+            .credentialsProvider(credentials)
+            .region(Region.US_EAST_1)
+            .build();
+
+    try (var client =
+        EventBridgeClient.builder()
+            .endpointOverride(getLocalstackEndpoint())
+            .credentialsProvider(credentials)
+            .region(Region.US_EAST_1)
+            .build()) {
+
+      var sqsResponse =
+          sqsClient.createQueue(CreateQueueRequest.builder().queueName(TEST_RESOURCE_NAME).build());
+      if (!sqsResponse.queueUrl().contains(TEST_RESOURCE_NAME)) {
+        fail("failed to create queue: " + sqsResponse.sdkHttpResponse());
+      }
+
+      var busResponse =
+          client.createEventBus(CreateEventBusRequest.builder().name(TEST_RESOURCE_NAME).build());
+      if (!busResponse.eventBusArn().contains(TEST_RESOURCE_NAME)) {
+        fail("failed to create event bus: " + busResponse.sdkHttpResponse());
+      }
+
+      var ruleResponse =
+          client.putRule(
+              PutRuleRequest.builder()
+                  .name(TEST_RESOURCE_NAME)
+                  .eventBusName(TEST_RESOURCE_NAME)
+                  .eventPattern("{\"source\":[{\"prefix\":\"kafka-connect\"}]}")
+                  .build());
+      if (!ruleResponse.ruleArn().contains(TEST_RESOURCE_NAME)) {
+        fail("failed to create rule: " + ruleResponse.sdkHttpResponse());
+      }
+
+      var targets =
+          PutTargetsRequest.builder()
+              .eventBusName(TEST_RESOURCE_NAME)
+              .rule(TEST_RESOURCE_NAME)
+              .targets(Target.builder().id(TEST_RESOURCE_NAME).arn(getQueueArn()).build());
+      var targetResponse = client.putTargets(targets.build());
+      if (!targetResponse.failedEntryCount().equals(0)) {
+        fail("failed to create target: " + targetResponse.failedEntries());
+      }
+    }
+  }
+
+  protected void startConnector(final Path connectorConfig, final String connectorName)
+      throws IOException, InterruptedException {
+    log.info(
+        "creating eventbridge sink connector with connector configuration from {}",
+        connectorConfig);
+    var request =
+        HttpRequest.newBuilder()
+            .uri(buildKafkaConnectURI("/connectors/"))
+            .POST(HttpRequest.BodyPublishers.ofFile(connectorConfig))
+            .setHeader("Accept", "application/json")
+            .setHeader("Content-Type", "application/json")
+            .build();
+
+    var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    log.info("kafka connect response {}", response);
+
+    assertThat(response.statusCode())
+        .withFailMessage(() -> "could not create connector")
+        .isBetween(200, 299);
+
+    await()
+        .atMost(5, SECONDS)
+        .pollInterval(1, SECONDS)
+        .untilAsserted(
+            () -> {
+              log.info("waiting for eventbridge sink connector to enter {} state", RUNNING_STATE);
+              var statusRequest =
+                  HttpRequest.newBuilder()
+                      .uri(buildKafkaConnectURI("/connectors/" + connectorName + "/status"))
+                      .setHeader("Accept", "application/json")
+                      .build();
+
+              var statusResponse =
+                  httpClient.send(statusRequest, HttpResponse.BodyHandlers.ofString());
+              assertThat(statusResponse.body()).contains(RUNNING_STATE);
+            });
+    log.info("eventbridge sink connector entered {} state", RUNNING_STATE);
+  }
+
+  protected void sendKafkaRecord(ProducerRecord<String, JsonNode> record) {
+    try {
+      kafkaProducer.send(record).get();
+      kafkaProducer.flush();
+      kafkaProducer.close(Duration.ofSeconds(3));
+    } catch (Exception e) {
+      fail("could not send json test record", e);
+    }
+    log.info("successfully sent json test record to kafka");
+  }
+
+  protected ReceiveMessageResponse receiveSqsMessages(int maxNumberOfMessages) {
+    return sqsClient.receiveMessage(
+        ReceiveMessageRequest.builder()
+            .queueUrl(getQueueUrl())
+            .maxNumberOfMessages(maxNumberOfMessages)
+            .build());
+  }
+
+  protected void putS3Object(String key, RequestBody requestBody) {
+    s3client.putObject(
+        PutObjectRequest.builder().bucket(TEST_BUCKET_NAME).key(key).build(), requestBody);
+  }
+
+  protected ListObjectsResponse listS3Objects() {
+    return s3client.listObjects(ListObjectsRequest.builder().bucket(TEST_BUCKET_NAME).build());
+  }
+
+  protected ResponseInputStream<GetObjectResponse> getS3Object(String key) {
+    return s3client.getObject(GetObjectRequest.builder().bucket(TEST_BUCKET_NAME).key(key).build());
+  }
+
+  private static File getComposeFile() {
+    var filename = System.getenv(COMPOSE_FILE_ENV);
+    if (filename == null || filename.trim().isEmpty()) {
+      fail(COMPOSE_FILE_ENV + " environment variable must be set");
+    }
+    return new File(filename);
+  }
+
+  private static String getKafkaVersion() {
+    var version = System.getenv(KAFKA_VERSION_ENV);
+    if (version == null || version.trim().isEmpty()) {
+      fail(KAFKA_VERSION_ENV + " environment variable must be set");
+    }
+    return version;
+  }
+
+  private URI getLocalstackEndpoint() {
+    var port = environment.getServicePort(LOCALSTACK_SERVICE, LOCALSTACK_EXPOSED_SERVICE_PORT);
+    return URI.create("http://localhost:" + port);
+  }
+
+  private URI buildKafkaConnectURI(String path) {
+    var port = environment.getServicePort(CONNECT_SERVICE, CONNECT_EXPOSED_SERVICE_PORT);
+    return URI.create("http://localhost:" + port + path);
+  }
+
+  private String getQueueUrl() {
+    var response =
+        sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(TEST_RESOURCE_NAME).build());
+    return response.queueUrl();
+  }
+
+  protected String getQueueArn() {
+    var response =
+        sqsClient.getQueueAttributes(
+            GetQueueAttributesRequest.builder()
+                .queueUrl(getQueueUrl())
+                .attributeNames(QUEUE_ARN)
+                .build());
+    var queueArn = response.attributes().get(QUEUE_ARN);
+    if (queueArn == null) {
+      fail("could not retrieve arn for queue " + TEST_RESOURCE_NAME);
+    }
+    return queueArn;
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidatorTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidatorTest.java
@@ -15,6 +15,8 @@ import java.util.List;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EventBridgeSinkConfigValidatorTest {
 
@@ -321,5 +323,47 @@ public class EventBridgeSinkConfigValidatorTest {
     var configValue = new ConfigValue(AWS_DETAIL_TYPES_MAPPER_CLASS);
     configValue.value("software.amazon.event.kafkaconnector.mapping.DefaultDetailTypeMapper");
     EventBridgeSinkConfigValidator.validate(configValue);
+  }
+
+  @Test
+  public void validEmptyOffloadingS3DefaultBucket() {
+    var configValue = new ConfigValue(AWS_OFFLOADING_S3_DEFAULT_BUCKET);
+    EventBridgeSinkConfigValidator.validate(configValue);
+  }
+
+  @Test
+  public void validOffloadingS3DefaultBucket() {
+    var configValue = new ConfigValue(AWS_OFFLOADING_S3_DEFAULT_BUCKET);
+    configValue.value("test");
+    EventBridgeSinkConfigValidator.validate(configValue);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"s3", "s 3", "-s3", "s3-"})
+  public void invalidOffloadingS3DefaultBucket(String value) {
+    var configValue = new ConfigValue(AWS_OFFLOADING_S3_DEFAULT_BUCKET);
+    configValue.value(value);
+    assertThrows(ConfigException.class, () -> EventBridgeSinkConfigValidator.validate(configValue));
+  }
+
+  @Test
+  public void validEmptyOffloadingS3DefaultFieldRef() {
+    var configValue = new ConfigValue(AWS_OFFLOADING_DEFAULT_FIELDREF);
+    EventBridgeSinkConfigValidator.validate(configValue);
+  }
+
+  @Test
+  public void validOffloadingS3DefaultFieldRef() {
+    var configValue = new ConfigValue(AWS_OFFLOADING_DEFAULT_FIELDREF);
+    configValue.value("$.detail.value.test");
+    EventBridgeSinkConfigValidator.validate(configValue);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"$", "$.detail", "$.detail.[*]"})
+  public void invalidOffloadingS3DefaultFieldRef(String value) {
+    var configValue = new ConfigValue(AWS_OFFLOADING_DEFAULT_FIELDREF);
+    configValue.value(value);
+    assertThrows(ConfigException.class, () -> EventBridgeSinkConfigValidator.validate(configValue));
   }
 }

--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorS3IT.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorS3IT.java
@@ -4,34 +4,45 @@
  */
 package software.amazon.event.kafkaconnector;
 
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.*;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.withJsonPath;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.sqs.model.Message;
 
 @TestMethodOrder(OrderAnnotation.class)
-public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnectorIT {
+public class EventBridgeSinkConnectorS3IT extends AbstractEventBridgeSinkConnectorIT {
 
-  private static final String TEST_EVENT_KEY = "eventbridge-e2e";
+  private static final String TEST_EVENT_KEY = "eventbridge-e2e-s3";
 
   @Test
   @Order(1)
   public void startConnector() throws IOException, InterruptedException {
-    startConnector(Path.of("e2e/connect-config.json"), "eventbridge-e2e");
+    startConnector(Path.of("e2e/connect-config-s3.json"), "eventbridge-e2e-s3");
   }
 
   @Test
@@ -41,11 +52,11 @@ public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnector
 
     var mapper = new ObjectMapper();
 
-    var sentTimestamp = LocalDateTime.now().toString();
+    var sendTimestamp = LocalDateTime.now().toString();
     var jsonTestEvent =
         mapper
             .createObjectNode()
-            .put("sentTimestamp", sentTimestamp)
+            .put("sentTimestamp", sendTimestamp)
             .put("message", "hello from kafka");
 
     // use as marker object
@@ -55,6 +66,7 @@ public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnector
     sendKafkaRecord(new ProducerRecord<>(TEST_RESOURCE_NAME, TEST_EVENT_KEY, jsonTestEvent));
 
     log.info("polling sqs queue {} for json test record", getQueueArn());
+    var s3ObjectArn = new AtomicReference<String>(null);
     await()
         .atMost(5, SECONDS)
         .pollInterval(1, SECONDS)
@@ -79,14 +91,24 @@ public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnector
                                           hasJsonPath("topic", equalTo(TEST_RESOURCE_NAME)),
                                           hasJsonPath("key", equalTo(TEST_EVENT_KEY)),
                                           hasJsonPath(
-                                              "value.sentTimestamp", equalTo(sentTimestamp)),
+                                              "value.sentTimestamp", equalTo(sendTimestamp)),
+                                          hasNoJsonPath("value.message"),
                                           hasJsonPath(
-                                              "value.message", equalTo("hello from kafka")))))),
+                                              "dataref", startsWith("arn:aws:s3:::test-bucket/")),
+                                          hasJsonPath(
+                                              "datarefJsonPath",
+                                              equalTo("$.detail.value.message")))))),
                       atIndex(0));
+
+              var document = JsonPath.parse(messages.get(0).body());
+              var dataRef = (String) document.read(JsonPath.compile("$.detail.dataref"));
+              s3ObjectArn.set(dataRef);
             });
 
     // use as marker object
     putS3Object("STOP", RequestBody.empty());
+
+    var s3ObjectKey = s3ObjectArn.get().substring("arn:aws:s3:::test-bucket/".length());
 
     var s3Objects = listS3Objects().contents();
     log.info("received s3 object(s): {}", s3Objects);
@@ -94,6 +116,8 @@ public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnector
     assertThat(s3Objects)
         .extracting(S3Object::key)
         // order is not ensured by LocalStack
-        .containsExactlyInAnyOrder("START", "STOP");
+        .containsExactlyInAnyOrder("START", s3ObjectKey, "STOP");
+
+    assertThat(getS3Object(s3ObjectKey)).asString(UTF_8).isEqualTo("hello from kafka");
   }
 }

--- a/src/test/java/software/amazon/event/kafkaconnector/cache/FifoCacheTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/cache/FifoCacheTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.cache;
+
+import static java.util.stream.IntStream.rangeClosed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Random;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class FifoCacheTest {
+
+  @Test
+  public void shouldRequireMaxSizeOne() {
+    var exception =
+        assertThrows(IllegalArgumentException.class, () -> new FifoCache<Integer, String>(0));
+
+    assertThat(exception).hasMessage("Maximum size must be at least one.");
+    assertThat(new FifoCache<Integer, String>(1)).isNotNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 4, 8, 16})
+  public void shouldKeepUpToMaxSize(int maxSize) {
+
+    var cache = new FifoCache<Integer, Integer>(maxSize);
+
+    // fill cache up to maximum
+    var values = randomInts(maxSize);
+    rangeClosed(1, maxSize)
+        .forEach(
+            key -> {
+              var value = values[key];
+              assertThat(cache.computeIfAbsent(key, (ignore) -> value)).isEqualTo(value);
+            });
+
+    // check that each entry is not updated
+    rangeClosed(1, maxSize)
+        .forEach(
+            key -> {
+              var value = values[key];
+              assertThat(cache.computeIfAbsent(key, (ignore) -> rnd.nextInt())).isEqualTo(value);
+            });
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 4, 8, 16})
+  public void shouldReplaceFirstEntry(int maxSize) {
+
+    var cache = new FifoCache<Integer, Integer>(maxSize);
+
+    // fill cache up to maximum
+    var values = randomInts(maxSize);
+    rangeClosed(1, maxSize)
+        .forEach(
+            key -> {
+              var value = values[key];
+              assertThat(cache.computeIfAbsent(key, (ignore) -> value)).isEqualTo(value);
+            });
+
+    // add entry into full cache
+    cache.computeIfAbsent(maxSize + 1, (ignore) -> 0);
+
+    assertThat(cache.computeIfAbsent(maxSize + 1, (ignore) -> maxSize + 1)).isEqualTo(0);
+
+    // check that entries with key in [2...maxsize] are not touched
+    rangeClosed(2, maxSize)
+        .forEach(
+            key -> {
+              var value = values[key];
+              assertThat(cache.computeIfAbsent(key, (ignore) -> rnd.nextInt())).isEqualTo(value);
+            });
+
+    // check that FIRST entry with key=1 is re-added as a result of replacement for (add) new entry
+    // to full cache
+    assertThat(cache.computeIfAbsent(1, (ignore) -> maxSize + 2))
+        .isNotEqualTo(values[1])
+        .isEqualTo(maxSize + 2);
+  }
+
+  private static final Random rnd = new Random();
+
+  private static int[] randomInts(int size) {
+    return rnd.ints(size + 1).toArray();
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/cache/MessageDigestCacheKeyTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/cache/MessageDigestCacheKeyTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class MessageDigestCacheKeyTest {
+
+  @Test
+  public void shouldImplementHashCode() {
+    var one = MessageDigestCacheKey.sha512Of("some text");
+    var two = MessageDigestCacheKey.sha512Of("some text");
+
+    assertThat(one.hashCode()).isEqualTo(two.hashCode());
+  }
+
+  @Test
+  public void shouldImplementEquals() {
+    var one = MessageDigestCacheKey.sha512Of("some text");
+    var two = MessageDigestCacheKey.sha512Of("some text");
+
+    assertThat(one).isEqualTo(two);
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(MessageDigestCacheKey.class).verify();
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloadingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/offloading/NoOpEventBridgeEventDetailValueOffloadingTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.offloading;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
+
+class NoOpEventBridgeEventDetailValueOffloadingTest {
+
+  private static final EventBridgeEventDetailValueOffloadingStrategy strategy =
+      new NoOpEventBridgeEventDetailValueOffloading();
+
+  @Test
+  @DisplayName("result of successful offloaded PutEventsRequestEntry should be empty")
+  public void keepEmpty() {
+    var actual = strategy.apply(emptyList());
+
+    assertThat(actual.success).isEmpty();
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @ParameterizedTest(name = "with size {0}")
+  @DisplayName("result of successful offloaded PutEventsRequestEntry should be unmodified")
+  @ValueSource(longs = {1, 10, 100})
+  public void keepSame(long size) {
+
+    var items =
+        Stream.generate(() -> new MappedSinkRecord<PutEventsRequestEntry>(null, null))
+            .limit(size)
+            .collect(toList());
+
+    var actual = strategy.apply(items);
+
+    assertThat(actual.success).hasSameElementsAs(items);
+    assertThat(actual.errors).isEmpty();
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloadingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/offloading/S3EventBridgeEventDetailValueOffloadingTest.java
@@ -1,0 +1,773 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.offloading;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.withJsonPath;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.joining;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.apache.kafka.connect.data.SchemaBuilder.array;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Index.atIndex;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.ErrorType.PANIC;
+import static software.amazon.event.kafkaconnector.EventBridgeResult.ErrorType.RETRY;
+import static software.amazon.event.kafkaconnector.offloading.S3EventBridgeEventDetailValueOffloading.JSON_PATH_PREFIX;
+
+import com.jayway.jsonpath.JsonPath;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.assertj.core.api.iterable.ThrowingExtractor;
+import org.hamcrest.MatcherAssert;
+import org.json.JSONException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.skyscreamer.jsonassert.JSONAssert;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;
+import software.amazon.event.kafkaconnector.cache.Cache;
+import software.amazon.event.kafkaconnector.cache.FifoCache;
+import software.amazon.event.kafkaconnector.cache.MessageDigestCacheKey;
+import software.amazon.event.kafkaconnector.mapping.DefaultEventBridgeMapper;
+import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
+
+@ExtendWith(MockitoExtension.class)
+class S3EventBridgeEventDetailValueOffloadingTest {
+
+  private final String BUCKET = "test";
+
+  private static final Schema ORDER_SCHEMA =
+      SchemaBuilder.struct()
+          .field("orderItems", array(STRING_SCHEMA))
+          .field("orderCreatedTime", OPTIONAL_STRING_SCHEMA)
+          .build();
+
+  private final Cache<MessageDigestCacheKey, UUID> s3ObjectKeyCache = (key, f) -> f.apply(key);
+
+  @Mock private S3AsyncClient s3Client;
+
+  @Captor private ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor;
+  @Captor private ArgumentCaptor<AsyncRequestBody> requestBodyCaptor;
+
+  @BeforeEach
+  void resetMocks() {
+    reset(s3Client);
+  }
+
+  @AfterEach
+  void verifyNoMoreMocksInteractions() {
+    verifyNoMoreInteractions(s3Client);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "$.detail..", "$.detail[value]"})
+  public void shouldRejectInvalidJsonPath(String jsonPathExp) {
+    var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new S3EventBridgeEventDetailValueOffloading(
+                    s3Client, BUCKET, jsonPathExp, s3ObjectKeyCache, UUID::randomUUID));
+    assertThat(exception).hasMessage(format("Invalid JSON Path '%s'.", jsonPathExp));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"$", "$.detail", "$.other"})
+  public void shouldRejectJsonPathWithUnsupportedPath(String jsonPathExp) {
+    var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new S3EventBridgeEventDetailValueOffloading(
+                    s3Client, BUCKET, jsonPathExp, s3ObjectKeyCache, UUID::randomUUID));
+    assertThat(exception)
+        .hasMessage(
+            format("JSON Path must start with '%s' but is '%s'.", JSON_PATH_PREFIX, jsonPathExp));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"$.detail.value.orderItems[*]", "$.detail.value[*]"})
+  public void shouldRejectNonDefiniteJsonPath(String jsonPathExp) {
+    var exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new S3EventBridgeEventDetailValueOffloading(
+                    s3Client, BUCKET, jsonPathExp, s3ObjectKeyCache, UUID::randomUUID));
+    assertThat(exception)
+        .hasMessage(format("JSON Path must be definite but '%s' is not.", jsonPathExp));
+  }
+
+  @Test
+  public void shouldPutFullSinkRecordValueWithJsonValue() {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("2d10c6f6-31e9-43b4-8706-51b4cf5534d8"))
+            .apply(mappedSinkRecords);
+
+    verify(s3Client).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture());
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(tuple("test", "2d10c6f6-31e9-43b4-8706-51b4cf5534d8"));
+    assertThat(requestBodyCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(requestBodyAsString())
+        .satisfies(
+            body ->
+                jsonStrictEquals(
+                    "{\"orderItems\":[\"item-1\",\"item-2\"],\"orderCreatedTime\":\"Wed Dec 27 18:51:39 CET 2023\"}",
+                    body),
+            atIndex(0));
+
+    assertThat(actual.success)
+        .hasSize(1)
+        .extracting(it -> it.getValue().detail())
+        .satisfies(
+            detail ->
+                MatcherAssert.assertThat(
+                    detail,
+                    isJson(
+                        allOf(
+                            hasNoJsonPath("$.value"),
+                            hasJsonPath(
+                                "$.dataref",
+                                equalTo("arn:aws:s3:::test/2d10c6f6-31e9-43b4-8706-51b4cf5534d8")),
+                            hasJsonPath("$.datarefJsonPath", equalTo("$.detail.value"))))),
+            atIndex(0));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldPutNothingOfSinkRecordValueWithNullJsonValue() {
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, null, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("fd807e9d-f92c-4c45-8bbb-f8164cc75b7e"))
+            .apply(mappedSinkRecords);
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                hasJsonPath("$.value", is(nullValue())),
+                hasNoJsonPath("$.dataref"),
+                hasNoJsonPath("$.datarefJsonPath"))));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  public void shouldPutSubDocumentOfSinkRecordValueWithJsonValue(
+      Struct value, String expectedS3ObjectPayload) {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value.orderItems",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("d9d624dc-8452-411e-935f-edc3d62cbae2"))
+            .apply(mappedSinkRecords);
+
+    verify(s3Client).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture());
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(tuple("test", "d9d624dc-8452-411e-935f-edc3d62cbae2"));
+    assertThat(requestBodyCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(requestBodyAsString())
+        .satisfies(s -> assertEquals(expectedS3ObjectPayload, s.get(0), STRICT));
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                withJsonPath(
+                    "$.value",
+                    allOf(
+                        hasNoJsonPath("orderItems"),
+                        hasJsonPath("orderCreatedTime", equalTo("Wed Dec 27 18:51:39 CET 2023")))),
+                hasJsonPath(
+                    "$.dataref", equalTo("arn:aws:s3:::test/d9d624dc-8452-411e-935f-edc3d62cbae2")),
+                hasJsonPath("$.datarefJsonPath", equalTo("$.detail.value.orderItems")))));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  public static Stream<Arguments> shouldPutSubDocumentOfSinkRecordValueWithJsonValue() {
+    return Stream.of(
+        Arguments.of(
+            new Struct(ORDER_SCHEMA)
+                .put("orderItems", List.of())
+                .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023"),
+            "[]"),
+        Arguments.of(
+            new Struct(ORDER_SCHEMA)
+                .put("orderItems", List.of("item-1"))
+                .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023"),
+            "[\"item-1\"]"),
+        Arguments.of(
+            new Struct(ORDER_SCHEMA)
+                .put("orderItems", List.of("item-1", "item-2"))
+                .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023"),
+            "[\"item-1\",\"item-2\"]"));
+  }
+
+  @Test
+  public void shouldPutEmptySubDocumentOfSinkRecordValueWithJsonValue() {
+
+    var emptyStruct = SchemaBuilder.struct().build();
+    var orderSchema =
+        SchemaBuilder.struct()
+            .field("orderItems", array(STRING_SCHEMA))
+            .field("orderCreatedTime", OPTIONAL_STRING_SCHEMA)
+            .field("orderHints", emptyStruct)
+            .build();
+
+    var value =
+        new Struct(orderSchema)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023")
+            .put("orderHints", new Struct(emptyStruct));
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", orderSchema, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value.orderHints",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("fbdacb19-441e-479b-a347-f7c5f82ccd70"))
+            .apply(mappedSinkRecords);
+
+    verify(s3Client).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture());
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(tuple("test", "fbdacb19-441e-479b-a347-f7c5f82ccd70"));
+    assertThat(requestBodyCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(requestBodyAsString())
+        .satisfies(s -> assertEquals("{}", s.get(0), STRICT));
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                withJsonPath(
+                    "$.value",
+                    allOf(
+                        hasJsonPath("orderItems", equalTo(List.of("item-1", "item-2"))),
+                        hasJsonPath("orderCreatedTime", equalTo("Wed Dec 27 18:51:39 CET 2023")))),
+                hasJsonPath(
+                    "$.dataref", equalTo("arn:aws:s3:::test/fbdacb19-441e-479b-a347-f7c5f82ccd70")),
+                hasJsonPath("$.datarefJsonPath", equalTo("$.detail.value.orderHints")))));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldPutNothingOfSinkRecordValueWithJsonValue() {
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value.orderId",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("eb8421ef-3b46-4ed7-806f-7326546ed12c"))
+            .apply(mappedSinkRecords);
+
+    verifyNoInteractions(s3Client);
+
+    assertThat(actual.success)
+        .hasSize(1)
+        .extracting(x -> x.getValue().detail())
+        .satisfies(
+            detail ->
+                jsonStrictEquals(
+                    "{\"topic\":\"topic\",\"partition\":0,\"offset\":0,\"timestamp\":null,\"timestampType\":\"NoTimestampType\",\"headers\":[],\"key\":\"1\",\"value\":{\"orderItems\":[\"item-1\",\"item-2\"],\"orderCreatedTime\":\"Wed Dec 27 18:51:39 CET 2023\"}}",
+                    detail),
+            atIndex(0));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldPutNothingOfSinkRecordValueWithSubDocumentNullJsonValue() {
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", null);
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value.orderCreatedTime",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("f3dd06ed-1daf-47ff-ab3e-f273158469aa"))
+            .apply(mappedSinkRecords);
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                withJsonPath(
+                    "$.value",
+                    allOf(
+                        hasJsonPath("orderItems", equalTo(List.of("item-1", "item-2"))),
+                        hasJsonPath("orderCreatedTime", is(nullValue())))),
+                hasNoJsonPath("$.dataref"),
+                hasNoJsonPath("$.datarefJsonPath"))));
+
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldPutFullSinkRecordValueWithStringValue() {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", STRING_SCHEMA, "Hello world", 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("55443a4d-4d15-49ef-a2b0-d89657a71d8a"))
+            .apply(mappedSinkRecords);
+
+    verify(s3Client).putObject(putObjectRequestCaptor.capture(), requestBodyCaptor.capture());
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(tuple("test", "55443a4d-4d15-49ef-a2b0-d89657a71d8a"));
+    assertThat(requestBodyCaptor.getAllValues())
+        .hasSize(1)
+        .extracting(requestBodyAsString())
+        .containsExactly("Hello world");
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                hasNoJsonPath("$.value"),
+                hasJsonPath(
+                    "$.dataref", equalTo("arn:aws:s3:::test/55443a4d-4d15-49ef-a2b0-d89657a71d8a")),
+                hasJsonPath("$.datarefJsonPath", equalTo("$.detail.value")))));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldPutNothingOfSinkRecordValueWithStringValue() {
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", STRING_SCHEMA, "Hello world", 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client,
+                BUCKET,
+                "$.detail.value.key",
+                s3ObjectKeyCache,
+                () -> UUID.fromString("37c43d04-147f-4e83-9890-b41fad756377"))
+            .apply(mappedSinkRecords);
+
+    verifyNoInteractions(s3Client);
+
+    assertThat(actual.success).hasSize(1);
+    MatcherAssert.assertThat(
+        actual.success.get(0).getValue().detail(),
+        isJson(
+            allOf(
+                hasJsonPath("$.value", equalTo("Hello world")),
+                hasNoJsonPath("$.dataref"),
+                hasNoJsonPath("$.datarefJsonPath"))));
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnRetryError() {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.completeExceptionally(
+        S3Exception.builder()
+            .statusCode(500)
+            .awsErrorDetails(AwsErrorDetails.builder().errorCode("InternalError").build())
+            .build());
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client, BUCKET, "$.detail.value", s3ObjectKeyCache, UUID::randomUUID)
+            .apply(mappedSinkRecords);
+
+    assertThat(actual.success).isEmpty();
+    assertThat(actual.errors)
+        .hasSize(1)
+        .extracting(it -> it.getValue().getType())
+        .containsExactly(RETRY);
+  }
+
+  @Test
+  public void shouldReturnPanicError() {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.completeExceptionally(
+        S3Exception.builder()
+            .statusCode(403)
+            .awsErrorDetails(
+                AwsErrorDetails.builder()
+                    .errorMessage(
+                        "The AWS Access Key Id you provided does not exist in our records.")
+                    .errorCode("InvalidAccessKeyId")
+                    .serviceName("S3")
+                    .build())
+            .build());
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client, BUCKET, "$.detail.value", s3ObjectKeyCache, UUID::randomUUID)
+            .apply(mappedSinkRecords);
+
+    assertThat(actual.success).isEmpty();
+    assertThat(actual.errors)
+        .hasSize(1)
+        .extracting(it -> it.getValue().getType())
+        .containsExactly(PANIC);
+  }
+
+  @Test
+  public void shouldUseCache() {
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(future);
+
+    @SuppressWarnings("unchecked")
+    var idGenerator = (Supplier<UUID>) mock(Supplier.class);
+    when(idGenerator.get())
+        .thenReturn(
+            UUID.fromString("0c6ec17a-19e8-4dd6-8696-f91e8edc7db0"),
+            UUID.fromString("322abe30-4839-4ea7-a547-c2df7be43aac"),
+            UUID.fromString("905b0f71-a69f-42db-9809-44c6103c9bae"));
+
+    var value1 =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var value2 =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-3"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value1, 0),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "2", ORDER_SCHEMA, value2, 1),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "3", ORDER_SCHEMA, value1, 2));
+
+    var actual =
+        new S3EventBridgeEventDetailValueOffloading(
+                s3Client, BUCKET, "$.detail.value.orderItems", new FifoCache<>(2), idGenerator)
+            .apply(mappedSinkRecords);
+
+    verify(s3Client, times(2))
+        .putObject(putObjectRequestCaptor.capture(), any(AsyncRequestBody.class));
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(
+            tuple("test", "0c6ec17a-19e8-4dd6-8696-f91e8edc7db0"),
+            tuple("test", "322abe30-4839-4ea7-a547-c2df7be43aac"));
+
+    assertThat(actual.success)
+        .extracting(it -> dataref(it.getValue().detail()))
+        .containsExactly(
+            "arn:aws:s3:::test/0c6ec17a-19e8-4dd6-8696-f91e8edc7db0",
+            "arn:aws:s3:::test/322abe30-4839-4ea7-a547-c2df7be43aac",
+            "arn:aws:s3:::test/0c6ec17a-19e8-4dd6-8696-f91e8edc7db0");
+
+    assertThat(actual.errors).isEmpty();
+  }
+
+  @Test
+  public void shouldNotUpdateCacheOnException() {
+
+    var futureException = new CompletableFuture<PutObjectResponse>();
+    futureException.completeExceptionally(
+        S3Exception.builder()
+            .statusCode(500)
+            .awsErrorDetails(AwsErrorDetails.builder().errorCode("InternalError").build())
+            .build());
+
+    var future = new CompletableFuture<PutObjectResponse>();
+    future.complete(null);
+
+    when(s3Client.putObject(any(PutObjectRequest.class), any(AsyncRequestBody.class)))
+        .thenReturn(futureException)
+        .thenReturn(future);
+
+    @SuppressWarnings("unchecked")
+    var idGenerator = (Supplier<UUID>) mock(Supplier.class);
+    when(idGenerator.get())
+        .thenReturn(
+            UUID.fromString("0c6ec17a-19e8-4dd6-8696-f91e8edc7db0"),
+            UUID.fromString("322abe30-4839-4ea7-a547-c2df7be43aac"));
+
+    var value =
+        new Struct(ORDER_SCHEMA)
+            .put("orderItems", List.of("item-1", "item-2"))
+            .put("orderCreatedTime", "Wed Dec 27 18:51:39 CET 2023");
+
+    var mappedSinkRecords =
+        withDefaultEventBridgeMapperMap(
+            getEventBridgeSinkConfig(),
+            new SinkRecord("topic", 0, STRING_SCHEMA, "1", ORDER_SCHEMA, value, 0));
+
+    var offloading =
+        new S3EventBridgeEventDetailValueOffloading(
+            s3Client, BUCKET, "$.detail.value.orderItems", new FifoCache<>(2), idGenerator);
+
+    assertThat(offloading.apply(mappedSinkRecords).errors).hasSize(1);
+
+    var actual = offloading.apply(mappedSinkRecords);
+
+    verify(s3Client, times(2))
+        .putObject(putObjectRequestCaptor.capture(), any(AsyncRequestBody.class));
+
+    assertThat(putObjectRequestCaptor.getAllValues())
+        .extracting(PutObjectRequest::bucket, PutObjectRequest::key)
+        .containsExactly(
+            tuple("test", "0c6ec17a-19e8-4dd6-8696-f91e8edc7db0"),
+            tuple("test", "322abe30-4839-4ea7-a547-c2df7be43aac"));
+
+    assertThat(actual.success)
+        .extracting(it -> dataref(it.getValue().detail()))
+        .containsExactly("arn:aws:s3:::test/322abe30-4839-4ea7-a547-c2df7be43aac");
+
+    assertThat(actual.errors).isEmpty();
+  }
+
+  private static String dataref(String json) {
+    return JsonPath.parse(json).read(JsonPath.compile("$.dataref"));
+  }
+
+  private static EventBridgeSinkConfig getEventBridgeSinkConfig() {
+    var properties = new Properties();
+    properties.setProperty("aws.eventbridge.connector.id", "eventbridge-e2e-connector");
+    properties.setProperty("aws.eventbridge.region", "us-east-1");
+    properties.setProperty("aws.eventbridge.endpoint.uri", "http://localstack:4566");
+    properties.setProperty(
+        "aws.eventbridge.eventbus.arn",
+        "arn:aws:events:us-east-1:000000000000:event-bus/eventbridge-e2e");
+
+    return new EventBridgeSinkConfig(properties);
+  }
+
+  private static ThrowingExtractor<AsyncRequestBody, String, IOException> requestBodyAsString() {
+    return (AsyncRequestBody requestBody) -> {
+      final StringBuffer sb = new StringBuffer();
+      try {
+        requestBody
+            .subscribe(bb -> sb.append(StandardCharsets.UTF_8.decode(bb)))
+            .get(1000, MILLISECONDS);
+      } catch (Exception ignore) {
+      }
+      return sb.toString();
+    };
+  }
+
+  private List<MappedSinkRecord<PutEventsRequestEntry>> withDefaultEventBridgeMapperMap(
+      final EventBridgeSinkConfig config, final SinkRecord... values) {
+    var mapper = new DefaultEventBridgeMapper(config);
+    var result = mapper.map(List.of(values));
+    if (!result.errors.isEmpty()) {
+      throw new IllegalStateException(
+          result.errors.stream()
+              .map(
+                  it ->
+                      String.format(
+                          "'%s' Cause: %s",
+                          it.getValue().getMessage(),
+                          Optional.ofNullable(it.getValue().getCause())
+                              .map(Throwable::toString)
+                              .orElse("n/a")))
+              .collect(joining()));
+    }
+    return result.success;
+  }
+
+  private void jsonStrictEquals(String expectedStr, String actualStr) {
+    try {
+      JSONAssert.assertEquals(expectedStr, actualStr, STRICT);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
EventBridge's PutEvents size limit is currently 256KB. Often, Kafka records are larger (default 1MB) and the connector drops (or DLQs, if configured) those records with a warning. By adding a new configuration property, the connector could send (sideline) those records to a configured event store, such as [S3](https://aws.amazon.com/s3/) e.g., by using the claim-check pattern, replacing the event payload with an S3 link (reference).

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#110


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.