### PR TITLE
feat: prefix each log messages w/ git commit id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,8 @@ Before proceeding, verify that the Docker Compose logs do not show any errors, s
 entries. You should see logs like:
 
 ```bash
-e2e-connect-1     | [2023-07-04 09:35:59,034] TRACE [eventbridge-e2e|task-0] EventBridgeSinkTask put called with 0 records: [] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:68)
-e2e-connect-1     | [2023-07-04 09:35:59,035] TRACE [eventbridge-e2e|task-0] Returning early: 0 records received (software.amazon.event.kafkaconnector.EventBridgeSinkTask:70)
+e2e-connect-1     | [2023-07-04 09:35:59,034] TRACE [eventbridge-e2e|task-0] [@69c7029] EventBridgeSinkTask put called with 0 records: [] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:68)
+e2e-connect-1     | [2023-07-04 09:35:59,035] TRACE [eventbridge-e2e|task-0] [@69c7029] Returning early: 0 records received (software.amazon.event.kafkaconnector.EventBridgeSinkTask:70)
 ```
 
 Produce a Kafka record to invoke the EventBridge sink connector: 
@@ -178,11 +178,11 @@ echo -n '{"hello":"world"}' | ./kafka-console-producer.sh --bootstrap-server kaf
 The Docker Compose logs output should look like:
 
 ```console
-e2e-connect-1     | [2023-07-04 09:54:55,824] TRACE [eventbridge-e2e|task-0] EventBridgeSinkTask put called with 1 records: [SinkRecord{kafkaOffset=1, timestampType=CreateTime} ConnectRecord{topic='eventbridge-e2e', kafkaPartition=0, key=null, keySchema=Schema{STRING}, value={hello=world}, valueSchema=null, timestamp=1688464495808, headers=ConnectHeaders(headers=)}] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:68)
-e2e-connect-1     | [2023-07-04 09:54:55,824] TRACE [eventbridge-e2e|task-0] putItems call started: start=2023-07-04T09:54:55.824953210Z attempts=1 maxRetries=2 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:81)
-e2e-connect-1     | [2023-07-04 09:54:55,825] TRACE [eventbridge-e2e|task-0] Sending request to EventBridge: PutEventsRequest(Entries=[PutEventsRequestEntry(Source=kafka-connect.eventbridge-e2e-connector, Resources=[], DetailType=kafka-connect-eventbridge-e2e, Detail={"topic":"eventbridge-e2e","partition":0,"offset":0,"timestamp":1688464495808,"timestampType":"CreateTime","headers":[],"key":null,"value":{"hello":"world"}}, EventBusName=arn:aws:events:us-east-1:1234567890:event-bus/eventbridge-e2e)]) (software.amazon.event.kafkaconnector.EventBridgeWriter:152)
-e2e-connect-1     | [2023-07-04 09:54:56,100] TRACE [eventbridge-e2e|task-0] putEvents response: [PutEventsResultEntry(EventId=29725ba0-c013-9457-0be2-51ba26708d3d)] (software.amazon.event.kafkaconnector.EventBridgeWriter:154)
-e2e-connect-1     | [2023-07-04 09:54:56,301] TRACE [eventbridge-e2e|task-0] putItems call completed: start=2023-07-04T09:54:55.824953210Z completion=2023-07-04T09:54:56.301049627Z durationMillis=476 attempts=1 maxRetries=2 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:105)
+e2e-connect-1     | [2023-07-04 09:54:55,824] TRACE [eventbridge-e2e|task-0] [@69c7029] EventBridgeSinkTask put called with 1 records: [SinkRecord{kafkaOffset=1, timestampType=CreateTime} ConnectRecord{topic='eventbridge-e2e', kafkaPartition=0, key=null, keySchema=Schema{STRING}, value={hello=world}, valueSchema=null, timestamp=1688464495808, headers=ConnectHeaders(headers=)}] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:68)
+e2e-connect-1     | [2023-07-04 09:54:55,824] TRACE [eventbridge-e2e|task-0] [@69c7029] putItems call started: start=2023-07-04T09:54:55.824953210Z attempts=1 maxRetries=2 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:81)
+e2e-connect-1     | [2023-07-04 09:54:55,825] TRACE [eventbridge-e2e|task-0] [@69c7029] Sending request to EventBridge: PutEventsRequest(Entries=[PutEventsRequestEntry(Source=kafka-connect.eventbridge-e2e-connector, Resources=[], DetailType=kafka-connect-eventbridge-e2e, Detail={"topic":"eventbridge-e2e","partition":0,"offset":0,"timestamp":1688464495808,"timestampType":"CreateTime","headers":[],"key":null,"value":{"hello":"world"}}, EventBusName=arn:aws:events:us-east-1:1234567890:event-bus/eventbridge-e2e)]) (software.amazon.event.kafkaconnector.EventBridgeWriter:152)
+e2e-connect-1     | [2023-07-04 09:54:56,100] TRACE [eventbridge-e2e|task-0] [@69c7029] putEvents response: [PutEventsResultEntry(EventId=29725ba0-c013-9457-0be2-51ba26708d3d)] (software.amazon.event.kafkaconnector.EventBridgeWriter:154)
+e2e-connect-1     | [2023-07-04 09:54:56,301] TRACE [eventbridge-e2e|task-0] [@69c7029] putItems call completed: start=2023-07-04T09:54:55.824953210Z completion=2023-07-04T09:54:56.301049627Z durationMillis=476 attempts=1 maxRetries=2 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:105)
 ```
 
 The output event should look similar to the below:

--- a/README.md
+++ b/README.md
@@ -513,8 +513,8 @@ ignore (skip) over the record. Optionally, a dead-letter topic can be
 [configured](#json-encoding-with-dead-letter-queue) where such records are sent to.
 
 ```console
-[2023-05-26 09:01:21,149] WARN [EventBridgeSink-Json|task-0] Marking record as failed: code=413 message=EventBridge batch size limit exceeded topic=json-test partition=0 offset=0 (software.amazon.event.kafkaconnector.EventBridgeWriter:244)
-[2023-05-26 09:01:21,149] WARN [EventBridgeSink-Json|task-0] Dead-letter queue not configured: skipping failed record (software.amazon.event.kafkaconnector.EventBridgeSinkTask:147)
+[2023-05-26 09:01:21,149] WARN [EventBridgeSink-Json|task-0] [@69c7029] Marking record as failed: code=413 message=EventBridge batch size limit exceeded topic=json-test partition=0 offset=0 (software.amazon.event.kafkaconnector.EventBridgeWriter:244)
+[2023-05-26 09:01:21,149] WARN [EventBridgeSink-Json|task-0] [@69c7029] Dead-letter queue not configured: skipping failed record (software.amazon.event.kafkaconnector.EventBridgeSinkTask:147)
 software.amazon.event.kafkaconnector.exceptions.EventBridgePartialFailureResponse: statusCode=413 errorMessage=EventBridge batch size limit exceeded topic=json-test partition=0 offset=0
 ```
 
@@ -534,11 +534,11 @@ By enabling `TRACE`-level logging, the connector will emit additional log messag
 client configuration, records received from Kafka Connect, `PutEvents` stats, such as start, end time and duration, etc.
 
 ```console
-[2023-05-25 12:01:56,882] TRACE [EventBridgeSink-Json|task-0] EventBridgeSinkTask put called with 1 records: [SinkRecord{kafkaOffset=0, timestampType=CreateTime} ConnectRecord{topic='json-test', kafkaPartition=0, key=my-key, keySchema=Schema{STRING}, value={sentTime=Thu May 25 14:01:56 CEST 2023}, valueSchema=null, timestamp=1685016116860, headers=ConnectHeaders(headers=)}] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:57)
-[2023-05-25 12:01:56,889] TRACE [EventBridgeSink-Json|task-0] EventBridgeSinkTask putItems call started: start=2023-05-25T12:01:56.889640Z attempts=1 maxRetries=0 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:77)
-[2023-05-25 12:01:56,909] TRACE [EventBridgeSink-Json|task-0] EventBridgeWriter sending request to eventbridge: PutEventsRequest(Entries=[PutEventsRequestEntry(Source=kafka-connect.json-test-connector, Resources=[], DetailType=kafka-connect-json-test, Detail={"topic":"json-test","partition":0,"offset":0,"timestamp":1685016116860,"timestampType":"CreateTime","headers":[],"key":"my-key","value":{"sentTime":"Thu May 25 14:01:56 CEST 2023"}}, EventBusName=arn:aws:events:us-east-1:1234567890:event-bus/kafkabus)]) (software.amazon.event.kafkaconnector.EventBridgeWriter:140)
-[2023-05-25 12:01:57,242] TRACE [EventBridgeSink-Json|task-0] EventBridgeWriter putEvents response: [PutEventsResultEntry(EventId=875b7f21-f098-8b55-ea7a-a4d235079bfb)] (software.amazon.event.kafkaconnector.EventBridgeWriter:142)
-[2023-05-25 12:01:57,242] TRACE [EventBridgeSink-Json|task-0] EventBridgeSinkTask putItems call completed: start=2023-05-25T12:01:56.889640Z completion=2023-05-25T12:01:57.242428Z durationMillis=352 attempts=1 maxRetries=0 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:99)
+[2023-05-25 12:01:56,882] TRACE [EventBridgeSink-Json|task-0] [@69c7029] EventBridgeSinkTask put called with 1 records: [SinkRecord{kafkaOffset=0, timestampType=CreateTime} ConnectRecord{topic='json-test', kafkaPartition=0, key=my-key, keySchema=Schema{STRING}, value={sentTime=Thu May 25 14:01:56 CEST 2023}, valueSchema=null, timestamp=1685016116860, headers=ConnectHeaders(headers=)}] (software.amazon.event.kafkaconnector.EventBridgeSinkTask:57)
+[2023-05-25 12:01:56,889] TRACE [EventBridgeSink-Json|task-0] [@69c7029] EventBridgeSinkTask putItems call started: start=2023-05-25T12:01:56.889640Z attempts=1 maxRetries=0 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:77)
+[2023-05-25 12:01:56,909] TRACE [EventBridgeSink-Json|task-0] [@69c7029] EventBridgeWriter sending request to eventbridge: PutEventsRequest(Entries=[PutEventsRequestEntry(Source=kafka-connect.json-test-connector, Resources=[], DetailType=kafka-connect-json-test, Detail={"topic":"json-test","partition":0,"offset":0,"timestamp":1685016116860,"timestampType":"CreateTime","headers":[],"key":"my-key","value":{"sentTime":"Thu May 25 14:01:56 CEST 2023"}}, EventBusName=arn:aws:events:us-east-1:1234567890:event-bus/kafkabus)]) (software.amazon.event.kafkaconnector.EventBridgeWriter:140)
+[2023-05-25 12:01:57,242] TRACE [EventBridgeSink-Json|task-0] [@69c7029] EventBridgeWriter putEvents response: [PutEventsResultEntry(EventId=875b7f21-f098-8b55-ea7a-a4d235079bfb)] (software.amazon.event.kafkaconnector.EventBridgeWriter:142)
+[2023-05-25 12:01:57,242] TRACE [EventBridgeSink-Json|task-0] [@69c7029] EventBridgeSinkTask putItems call completed: start=2023-05-25T12:01:56.889640Z completion=2023-05-25T12:01:57.242428Z durationMillis=352 attempts=1 maxRetries=0 (software.amazon.event.kafkaconnector.EventBridgeSinkTask:99)
 ```
 
 Depending on your Kafka Connect environment, you can enable `TRACE`-level logging via environment variables on Kafka

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>7.0.0</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfig.java
@@ -12,7 +12,7 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 
 public class EventBridgeSinkConfig extends AbstractConfig {
 
@@ -73,7 +73,7 @@ public class EventBridgeSinkConfig extends AbstractConfig {
   public final List<String> resources;
   public final int maxRetries;
   public final long retriesDelay;
-  private final Logger log = LoggerFactory.getLogger(EventBridgeSinkConfig.class);
+  private final Logger log = ContextAwareLoggerFactory.getLogger(EventBridgeSinkConfig.class);
   private Map<String, String> detailTypeByTopic;
   private String detailType;
 

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidator.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidator.java
@@ -17,8 +17,6 @@ import java.util.stream.Stream;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionMetadata;
 
@@ -29,8 +27,6 @@ public class EventBridgeSinkConfigValidator {
   interface EnvVarGetter {
     String get(String name);
   }
-
-  private static final Logger log = LoggerFactory.getLogger(EventBridgeSinkConfigValidator.class);
 
   public static void validate(Config config) {
     config.configValues().stream()

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnector.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnector.java
@@ -14,12 +14,12 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 import software.amazon.event.kafkaconnector.util.PropertiesUtil;
 
 public class EventBridgeSinkConnector extends SinkConnector {
 
-  private final Logger log = LoggerFactory.getLogger(EventBridgeSinkConnector.class);
+  private final Logger log = ContextAwareLoggerFactory.getLogger(EventBridgeSinkConnector.class);
 
   private Map<String, String> originalProps;
 

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkTask.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkTask.java
@@ -21,15 +21,15 @@ import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.event.kafkaconnector.exceptions.EventBridgePartialFailureResponse;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 import software.amazon.event.kafkaconnector.util.PropertiesUtil;
 import software.amazon.event.kafkaconnector.util.StatusReporter;
 
 public class EventBridgeSinkTask extends SinkTask {
 
-  private final Logger log = LoggerFactory.getLogger(EventBridgeSinkTask.class);
+  private final Logger log = ContextAwareLoggerFactory.getLogger(EventBridgeSinkTask.class);
   private EventBridgeWriter eventBridgeWriter;
   private ErrantRecordReporter dlq;
   private EventBridgeSinkConfig config;

--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeWriter.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeWriter.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -43,6 +42,7 @@ import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.event.kafkaconnector.auth.EventBridgeCredentialsProvider;
 import software.amazon.event.kafkaconnector.batch.DefaultEventBridgeBatching;
 import software.amazon.event.kafkaconnector.batch.EventBridgeBatchingStrategy;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 import software.amazon.event.kafkaconnector.mapping.DefaultEventBridgeMapper;
 import software.amazon.event.kafkaconnector.mapping.EventBridgeMapper;
 import software.amazon.event.kafkaconnector.util.EventBridgeEventId;
@@ -52,7 +52,7 @@ import software.amazon.event.kafkaconnector.util.PropertiesUtil;
 public class EventBridgeWriter {
 
   private static final int SDK_TIMEOUT = 5000; // timeout in milliseconds for SDK calls
-  private static final Logger log = LoggerFactory.getLogger(EventBridgeWriter.class);
+  private static final Logger log = ContextAwareLoggerFactory.getLogger(EventBridgeWriter.class);
 
   private final EventBridgeSinkConfig config;
   private final EventBridgeAsyncClient ebClient;

--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
@@ -5,7 +5,6 @@
 package software.amazon.event.kafkaconnector.auth;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -13,12 +12,14 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 
 /** IAMUtility offers convenience functions for creating AWS IAM credential providers. */
 public class EventBridgeCredentialsProvider {
 
   private static final int stsRefreshDuration = 900; // min allowed value
-  private static final Logger log = LoggerFactory.getLogger(EventBridgeCredentialsProvider.class);
+  private static final Logger log =
+      ContextAwareLoggerFactory.getLogger(EventBridgeCredentialsProvider.class);
 
   /**
    * Create an IAM credentials provider.

--- a/src/main/java/software/amazon/event/kafkaconnector/batch/DefaultEventBridgeBatching.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/batch/DefaultEventBridgeBatching.java
@@ -17,8 +17,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
 
 /**
@@ -45,7 +45,8 @@ import software.amazon.event.kafkaconnector.util.MappedSinkRecord;
  */
 public class DefaultEventBridgeBatching implements EventBridgeBatchingStrategy {
 
-  private static final Logger logger = LoggerFactory.getLogger(DefaultEventBridgeBatching.class);
+  private static final Logger logger =
+      ContextAwareLoggerFactory.getLogger(DefaultEventBridgeBatching.class);
 
   private final Collector<
           MappedSinkRecord<PutEventsRequestEntry>,

--- a/src/main/java/software/amazon/event/kafkaconnector/logging/ContextAwareLoggerFactory.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/logging/ContextAwareLoggerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.logging;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+/**
+ * This logger factory creates logger with a static context. Currently, each log message is prefixed
+ * with the Git information of <code>git describe --abbrev --always --dirty</code>. The prefix
+ * pattern (RegEx) is <code>\[@[0-9a-f]{7}(-dirty)?]</code>.
+ *
+ * @author Andreas Gebhardt
+ * @since 1.3.0
+ */
+public class ContextAwareLoggerFactory {
+
+  private static final LogContext context;
+
+  static {
+    var properties = new Properties();
+    try {
+      var resource = ContextAwareLoggerFactory.class.getResource("/git.properties");
+      if (resource != null) {
+        try (var stream = resource.openStream()) {
+          properties.load(stream);
+        }
+      }
+    } catch (NullPointerException | IOException ignore) {
+    }
+    context =
+        new LogContext(
+            Optional.ofNullable(properties.get("git.commit.id.abbrev"))
+                .map(
+                    id ->
+                        String.format(
+                            "[@%s%s] ",
+                            id, "true".equals(properties.get("git.dirty")) ? "-dirty" : ""))
+                .orElse("unknown-git-rev"));
+  }
+
+  /**
+   * Return a logger named corresponding to the class passed as parameter and the static context
+   * wich prefix each log message.
+   *
+   * @param clazz the returned logger will be named after clazz
+   * @return logger
+   */
+  public static Logger getLogger(Class<?> clazz) {
+    return context.logger(clazz);
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/util/PropertiesUtil.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/util/PropertiesUtil.java
@@ -7,11 +7,11 @@ package software.amazon.event.kafkaconnector.util;
 import java.io.InputStream;
 import java.util.Properties;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 
 public class PropertiesUtil {
 
-  private static final Logger log = LoggerFactory.getLogger(PropertiesUtil.class);
+  private static final Logger log = ContextAwareLoggerFactory.getLogger(PropertiesUtil.class);
 
   private static final String CONNECTOR_VERSION = "connector.version";
   private static final String CONNECTOR_NAME = "connector.name";

--- a/src/main/java/software/amazon/event/kafkaconnector/util/StatusReporter.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/util/StatusReporter.java
@@ -9,14 +9,14 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import software.amazon.event.kafkaconnector.logging.ContextAwareLoggerFactory;
 
 /** The StatusReporter is a scheduled task that logs the throughput of the connector */
 public class StatusReporter {
 
   private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
-  private final Logger log = LoggerFactory.getLogger(StatusReporter.class);
+  private final Logger log = ContextAwareLoggerFactory.getLogger(StatusReporter.class);
   private final AtomicInteger totalRecordsSent = new AtomicInteger(0);
 
   private final long interval;

--- a/src/test/java/software/amazon/event/kafkaconnector/TestUtils.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/TestUtils.java
@@ -14,6 +14,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -27,6 +28,9 @@ public abstract class TestUtils {
   private TestUtils() {}
 
   public static final Schema testSchema = SchemaBuilder.struct().field("id", STRING_SCHEMA).build();
+
+  public static final Function<String, String> toFixedGitCommitId =
+      it -> it.replaceAll("\\[@[0-9a-f]+(-dirty)?]", "[GitCommitId]");
 
   public abstract static class OfSinkRecord {
 

--- a/src/test/java/software/amazon/event/kafkaconnector/batch/DefaultEventBridgeBatchingTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/batch/DefaultEventBridgeBatchingTest.java
@@ -11,6 +11,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static software.amazon.event.kafkaconnector.TestUtils.toFixedGitCommitId;
 import static software.amazon.event.kafkaconnector.batch.DefaultEventBridgeBatching.getSize;
 
 import ch.qos.logback.classic.Logger;
@@ -192,8 +193,9 @@ class DefaultEventBridgeBatchingTest {
     assertThat(strategy.apply(records)).isNotEmpty();
     assertThat(loggingEvents)
         .extracting(Object::toString)
+        .map(toFixedGitCommitId)
         .contains(
-            "[WARN] Item for SinkRecord with topic='topic', partition=0 and offset=0 exceeds EventBridge size limit. Size is 262145 bytes.");
+            "[WARN] [GitCommitId] Item for SinkRecord with topic='topic', partition=0 and offset=0 exceeds EventBridge size limit. Size is 262145 bytes.");
   }
 
   @Test

--- a/src/test/java/software/amazon/event/kafkaconnector/logging/ContextAwareLoggerFactoryTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/logging/ContextAwareLoggerFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.logging;
+
+import static ch.qos.logback.classic.Level.TRACE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.event.Level;
+import software.amazon.event.kafkaconnector.TestUtils;
+
+class ContextAwareLoggerFactoryTest {
+
+  private static TestUtils.ListAppender appender;
+
+  @BeforeAll
+  public static void setup() {
+    appender = TestUtils.ListAppender.of(ContextAwareLoggerFactoryTest.class, TRACE);
+    appender.start();
+  }
+
+  @AfterAll
+  public static void teardown() {
+    appender.detach();
+  }
+
+  @AfterEach
+  public void clearLoggingEvents() {
+    appender.clear();
+  }
+
+  @ParameterizedTest(name = "log event with level {0}")
+  @DisplayName(
+      "each logging message should be prefixed with short git commit hash: \\[@[0-9a-f]+(-dirty)?]")
+  @EnumSource(Level.class)
+  void shouldContainGitCommitIdPrefix(Level level) {
+    var logger = ContextAwareLoggerFactory.getLogger(ContextAwareLoggerFactoryTest.class);
+
+    logger
+        .makeLoggingEventBuilder(level)
+        .log("Just a {} with {} arguments at level {}", "test", 3, level);
+
+    var loggingEvents = appender.getLoggingEvents();
+    assertThat(loggingEvents).hasSize(1);
+    assertThat(loggingEvents.get(0).getFormattedMessage())
+        .matches("\\[@[0-9a-f]+(-dirty)?] Just a test with 3 arguments at level " + level);
+  }
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/util/StatusReporterTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/util/StatusReporterTest.java
@@ -11,6 +11,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static software.amazon.event.kafkaconnector.TestUtils.toFixedGitCommitId;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -57,16 +58,17 @@ public class StatusReporterTest {
     var task = scheduler.scheduleAtFixedRate(() -> sut.setSentRecords(1), 175, 75, MILLISECONDS);
 
     await()
-        .atMost(200, SECONDS)
+        .atMost(5, SECONDS)
         .untilAsserted(
             () ->
                 assertThat(appender.getLoggingEvents())
                     .filteredOn(level(INFO))
                     .extracting(ILoggingEvent::getFormattedMessage)
-                    .contains("Starting status reporter")
-                    .filteredOn(startsWith("Total records sent="))
+                    .map(toFixedGitCommitId)
+                    .contains("[GitCommitId] Starting status reporter")
+                    .filteredOn(startsWith("[GitCommitId] Total records sent="))
                     .hasSizeGreaterThan(2)
-                    .isSortedAccordingTo(matchGroupOf("Total records sent=(\\d+)")));
+                    .isSortedAccordingTo(matchGroupOf("[GitCommitId] Total records sent=(\\d+)")));
 
     task.cancel(false);
     sut.stopAsync();


### PR DESCRIPTION
<!--- Title -->

Description
-----------

The log message is prefixed with the git commit id from the current build, similar to `git describe --abbrev --always --dirty`.
  The prefix patern (RegEx) is: \[@[0-9a-f]+(-dirty)?]

Test Steps
-----------

`mvn clean test`

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#192, #216

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.