### PR TITLE
`bitnami/kafka` Images use more specific tag

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         java: ["11", "17"]
-        kafka: ["3.5.2","3.6.1"]
+        kafka: ["3.5.2-debian-11-r1","3.6.1-debian-11-r1"]
         broker: ["kafka","redpanda"]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ mvn clean package -Drevision=$(git describe --tags --always)
 To execute the integration tests (requires [Docker](https://docker.com/)) run:
 
 ```bash
-export KAFKA_VERSION=3.6.1
+export KAFKA_VERSION=3.6.1-debian-11-r1
 export COMPOSE_FILE=e2e/docker_compose.yaml
 mvn clean verify -Drevision=$(git describe --tags --always)
 ```

--- a/e2e/docker_compose.yaml
+++ b/e2e/docker_compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.1}
+    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.1-debian-11-r1}
     ports:
       - "9092:9092"
     environment:
@@ -22,7 +22,7 @@ services:
       - ${PWD}/log4j.properties:/opt/bitnami/kafka/config/log4j.properties
 
   connect:
-    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.1}
+    image: docker.io/bitnami/kafka:${KAFKA_VERSION:-3.6.1-debian-11-r1}
     depends_on:
       - kafka
     ports:


### PR DESCRIPTION

<!--- Title -->

Description
-----------

<!--- Describe your changes in detail. -->

There is a regression in CI with `bitnami/kafka` images using Debian versions > `debian-11-r1`. This was uncovered because Docker tags are mutable and a tag of `3.6.1` for example is moving across Debian/Bitnami releases. This change uses a more stable (yet still mutable) tag for the `bitnami/kafka` images.

Test Steps
-----------

CI E2E passes

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes: #222

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.