### PR TITLE
Custom Topic to Detail Type mapping

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidator.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidator.java
@@ -86,6 +86,12 @@ public class EventBridgeSinkConfigValidator {
           validateProfileName(configValue, getenv);
           break;
         }
+
+      case AWS_DETAIL_TYPES_MAPPER_CLASS:
+        {
+          validateDetailTypeMapperClass(configValue);
+          break;
+        }
     }
   }
 
@@ -93,6 +99,16 @@ public class EventBridgeSinkConfigValidator {
     var connectorId = (String) configValue.value();
     if (connectorId == null || connectorId.trim().isBlank()) {
       throw new ConfigException(configValue.name() + " must be set");
+    }
+  }
+
+  private static void validateDetailTypeMapperClass(ConfigValue configValue) {
+    var mapperClass = (String) configValue.value();
+    try {
+      Class.forName(mapperClass);
+    } catch (ClassNotFoundException e) {
+      throw new ConfigException(
+          mapperClass + " can't be loaded. Ensure the class path you have specified is correct.");
     }
   }
 

--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultDetailTypeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DefaultDetailTypeMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.mapping;
+
+import static software.amazon.event.kafkaconnector.EventBridgeSinkConfig.AWS_DETAIL_TYPES_DEFAULT;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;
+
+public class DefaultDetailTypeMapper implements DetailTypeMapper {
+
+  private EventBridgeSinkConfig eventBridgeSinkConfig;
+
+  @Override
+  public String getDetailType(SinkRecord sinkRecord) {
+    var detailType = eventBridgeSinkConfig.detailType;
+    if (detailType != null) return detailType.replace("${topic}", sinkRecord.topic());
+    return eventBridgeSinkConfig.detailTypeByTopic.getOrDefault(
+        sinkRecord.topic(), AWS_DETAIL_TYPES_DEFAULT.replace("${topic}", sinkRecord.topic()));
+  }
+
+  @Override
+  public void configure(EventBridgeSinkConfig eventBridgeSinkConfig) {
+    this.eventBridgeSinkConfig = eventBridgeSinkConfig;
+  }
+}

--- a/src/main/java/software/amazon/event/kafkaconnector/mapping/DetailTypeMapper.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/mapping/DetailTypeMapper.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.event.kafkaconnector.mapping;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;
+
+public interface DetailTypeMapper {
+  String getDetailType(SinkRecord record);
+
+  void configure(EventBridgeSinkConfig eventBridgeSinkConfig);
+}

--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidatorTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConfigValidatorTest.java
@@ -303,4 +303,23 @@ public class EventBridgeSinkConfigValidatorTest {
           EventBridgeSinkConfigValidator.validate(configValue);
         });
   }
+
+  @Test
+  public void invalidTopicDetailTypeMapperClass() {
+    var configValue = new ConfigValue(AWS_DETAIL_TYPES_MAPPER_CLASS);
+    configValue.value("com.xyz.completely.made.up");
+
+    assertThrows(
+        ConfigException.class,
+        () -> {
+          EventBridgeSinkConfigValidator.validate(configValue);
+        });
+  }
+
+  @Test
+  public void validTopicDetailTypeMapperClass() {
+    var configValue = new ConfigValue(AWS_DETAIL_TYPES_MAPPER_CLASS);
+    configValue.value("software.amazon.event.kafkaconnector.mapping.DefaultDetailTypeMapper");
+    EventBridgeSinkConfigValidator.validate(configValue);
+  }
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Adding DetailTypeMapper interface to be able to provide custom implementation for mapping a record based on the Kafka Topic or additional fields to EventBridge detailType. Current behavior will be set as default and is implemented by DefaultDetailTypeMapper.

Test Steps
-----------

Unit tests included

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#27 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.