### PR TITLE
test: assert Kafka connector task state

### DIFF
--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorIT.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorIT.java
@@ -96,4 +96,10 @@ public class EventBridgeSinkConnectorIT extends AbstractEventBridgeSinkConnector
         // order is not ensured by LocalStack
         .containsExactlyInAnyOrder("START", "STOP");
   }
+
+  @Order(3)
+  @Test
+  public void connectorTaskIsRunning() throws IOException, InterruptedException {
+    assertThat(connectorStateOfTask(0)).isEqualTo("RUNNING");
+  }
 }

--- a/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorS3IT.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/EventBridgeSinkConnectorS3IT.java
@@ -120,4 +120,10 @@ public class EventBridgeSinkConnectorS3IT extends AbstractEventBridgeSinkConnect
 
     assertThat(getS3Object(s3ObjectKey)).asString(UTF_8).isEqualTo("hello from kafka");
   }
+
+  @Order(3)
+  @Test
+  public void connectorTaskIsRunning() throws IOException, InterruptedException {
+    assertThat(connectorStateOfTask(0)).isEqualTo("RUNNING");
+  }
 }


### PR DESCRIPTION
Description
-----------

Improve integration test(s) by asserting Kafka connector task state is 'RUNNING' after execution of test case(s).

Test Steps
-----------

```
mvn clean verify
```

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes #297.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.