### PR TITLE
Leverage default profile supplier for credential reload

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProvider.java
@@ -7,6 +7,7 @@ package software.amazon.event.kafkaconnector.auth;
 import org.slf4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -51,6 +52,10 @@ public class EventBridgeCredentialsProvider {
   private static DefaultCredentialsProvider getDefaultCredentialsProvider(
       EventBridgeSinkConfig config) {
     var builder = DefaultCredentialsProvider.builder();
+
+    // Leverage DefaultSupplier to automatically reload credentials on file refresh
+    // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html#profile-reloading
+    builder.profileFile(ProfileFileSupplier.defaultSupplier());
 
     var profileName = config.profileName;
     if (!profileName.isBlank()) {


### PR DESCRIPTION
Description
-----------

Leverage Default Profile Supplier for credentials reload as in: https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html#profile-reloading

Test Steps
-----------

TBD

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

#357 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.