### PR TITLE
e2e: run only on one Java version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: ["11", "17"]
+        java: ["17"]
         kafka: ["3.7.1","3.8.0"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: ["11", "17"]
+        java: ["17"]
         kafka: ["7.5.4","7.6.1"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [ "11", "17" ]
+        java: ["17"]
         kafka: ["3.7.1","3.8.0"]
         redpanda: ["v24.2.1"]
       fail-fast: false


### PR DESCRIPTION


<!--- Title -->

Description
-----------

The Kafka Connector is running on the provided Java version of Kafka Connect, hence it's enough to run the e2e test(s) only once for each Kafka|Redpanda/Kafka Connect combination.

Test Steps
-----------

<!-- Describe the steps to reproduce. -->

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes #367.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.