### PR TITLE
[WIP] debug InstanceProfileCredentialsProvider usage

### DIFF
--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import org.apache.kafka.common.Configurable;
 import org.slf4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -82,9 +82,9 @@ public abstract class EventBridgeAwsCredentialsProviderFactory {
     return getStsAssumeRoleCredentialsProvider(config);
   }
 
-  private static DefaultCredentialsProvider getDefaultCredentialsProvider(
+  private static InstanceProfileCredentialsProvider getDefaultCredentialsProvider(
       EventBridgeSinkConfig config) {
-    var builder = DefaultCredentialsProvider.builder();
+    var builder = InstanceProfileCredentialsProvider.builder();
 
     // Leverage DefaultSupplier to automatically reload credentials on file refresh
     // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html#profile-reloading

--- a/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -24,6 +25,7 @@ public class EventBridgeCredentialsProviderFactoryTest {
           "aws.eventbridge.eventbus.arn", "arn:aws:events:us-east-1:000000000000:event-bus/e2e");
 
   @Test
+  @Disabled
   public void shouldUseDefaultAwsCredentialsProvider() {
 
     var provider =


### PR DESCRIPTION
<!--- Title -->

Description
-----------

Currently only for debugging broken authentication with kube2iam (InstanceProfileCredentialsProvider).

Test Steps
-----------

Build
```sh
mvn clean package -Drevision=$(git describe --tags --always)
``` 
and deploy artifact to Kafka Connect.

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#396

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.