### PR TITLE
build(deps-dev): bump testcontainers from 1.20.2 to 1.20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <org.mockito.version>5.14.2</org.mockito.version>
         <org.slf4j.version>2.0.16</org.slf4j.version>
         <org.skyscreamer.version>1.5.3</org.skyscreamer.version>
-        <org.testcontainers.version>1.20.2</org.testcontainers.version>
+        <org.testcontainers.version>1.20.3</org.testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/test/java/software/amazon/event/kafkaconnector/AbstractEventBridgeSinkConnectorIT.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/AbstractEventBridgeSinkConnectorIT.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.json.JsonSerializer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
@@ -38,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -84,8 +84,7 @@ public abstract class AbstractEventBridgeSinkConnectorIT {
   protected static final Logger log =
       LoggerFactory.getLogger(AbstractEventBridgeSinkConnectorIT.class);
 
-  @Container
-  private static final DockerComposeContainer<?> environment =
+  private final DockerComposeContainer<?> environment =
       new DockerComposeContainer<>("e2e", getComposeFile())
           .withLogConsumer("connect", new Slf4jLogConsumer(log).withSeparateOutputStreams())
           .withEnv("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
@@ -120,6 +119,16 @@ public abstract class AbstractEventBridgeSinkConnectorIT {
           new JsonSerializer());
 
   @BeforeAll
+  public void setup() {
+    environment.start();
+    createAwsResources();
+  }
+
+  @AfterAll
+  public void tearDown() {
+    environment.stop();
+  }
+
   public void createAwsResources() {
     log.info("creating aws localstack resources");
     var credentials =


### PR DESCRIPTION
Description
-----------

With [tc-gh9370] Docker compose initialization is cleared. The shared (static) Docker compose instance is not valid in successive tests anymore.

Fixed it by running Docker compose for each test class.

[tc-gh9370]: https://github.com/testcontainers/testcontainers-java/pull/9370


Test Steps
-----------

```sh
mvn clean verify -Drevision=$(git describe --tags --always)
```

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.