### PR TITLE
fix: cve-2024-57699 in jsonpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <ch.qos.logback.version>1.5.18</ch.qos.logback.version>
         <com.fasterxml.jackson.version>2.19.0</com.fasterxml.jackson.version>
         <com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
+        <net.minidev.json-smart.version>2.5.2</net.minidev.json-smart.version>
         <commons-codec.version>1.18.0</commons-codec.version>
         <commons-logging.version>1.3.5</commons-logging.version>
         <connect.api.version>3.9.1</connect.api.version>
@@ -181,6 +182,12 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
+            </dependency>
+            <!-- explicit override to fix vulnerability https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-57699 since JsonPath is not updated -->
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${net.minidev.json-smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION

<!--- Title -->

Description
-----------

Overwrites transitive dependency version used by JsonPath

Test Steps
-----------

Tests continue to pass.

Checklist:
----------

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

Closes: #567


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.